### PR TITLE
X-Ray spectra and ORCA 4.0 support

### DIFF
--- a/libavogadro/src/extensions/animationextension.cpp
+++ b/libavogadro/src/extensions/animationextension.cpp
@@ -35,6 +35,8 @@
 
 #include <QMessageBox>
 #include <QDir>
+#include <QDebug>
+
 
 #include <fstream>
 
@@ -261,7 +263,8 @@ namespace Avogadro {
                               tr( "Problem reading traj file %1").arg(trajfile));
         return;
       }
-
+        qDebug() << "tmpMol.NumAtoms()" << tmpMol.NumAtoms();
+        qDebug() << " m_molecule->numAtoms()" <<  m_molecule->numAtoms();
       if (tmpMol.NumAtoms() != m_molecule->numAtoms()) {
         QMessageBox::warning( NULL, tr( "Avogadro" ),
           tr( "Trajectory file %1 disagrees on the number of atoms in the present molecule").arg(trajfile));

--- a/libavogadro/src/extensions/orca/orcadata.cpp
+++ b/libavogadro/src/extensions/orca/orcadata.cpp
@@ -172,7 +172,7 @@ QString OrcaBasicData::getMethodTxt()
 QString OrcaBasicData::getBasisTxt()
 {
     // Translate the enum basis set to normal text
-    // enum basisType {SVP, TZVP, TZVPP, QZVP }
+    // enum basisType {SVP, TZVP, TZVPP, QZVPP }
     QString returnBasis = m_enumBasis.valueToKey(m_basisType);
     returnBasis.prepend("def2-");
     return returnBasis;
@@ -184,8 +184,8 @@ QString OrcaBasicData::getBasisTxt()
 //        return "def2-TZVP";
 //    case TZVPP:
 //        return "def2-TZVPP";
-//    case QZVP:
-//        return "def2-QZVP";
+//    case QZVPP:
+//        return "def2-QZVPP";
 //    default:
 //        return "";
 //    }
@@ -195,12 +195,12 @@ QString OrcaBasicData::getFormatTxt()
 {
     switch (m_coordsType)
     {
-    case ZMATRIX:
-        return "z-Matrix";
     case CARTESIAN:
-        return "*xyz";
+        return "* xyz";
+    case INTERNAL_COORDS:
+        return "* int";
     case ZMATRIX_COMPACT:
-        return "z-Matrix compact";
+        return "* gzmt";
     default:
         return "";
     }
@@ -212,34 +212,38 @@ OrcaBasisData::OrcaBasisData()
      m_auxBasis = OrcaExtension::SVP;
      m_auxCorrBasis = OrcaExtension::SVP;
 
-     m_useEPC = false;
-     m_useAuxEPC = false;
-     m_useAuxCorrEPC = false;
-     m_useRel = false;
-     m_useDKH = false;
-     m_rel = ZORA;
-     m_DKHOrder = 0;
+//     m_useEPC = false;
+
+//     m_useAuxEPC = false;
+//     m_useAuxCorrEPC = false;
+//     m_useRel = false;
+//     m_useDKH = false;
+//     m_rel = ZORA;
+//     m_DKHOrder = 0;
 }
 void OrcaBasisData::reset()
 {
      m_basis= OrcaExtension::SVP;
      m_auxBasis = OrcaExtension::SVP;
      m_auxCorrBasis = OrcaExtension::SVP;
-     m_useEPC = false;
-     m_useAuxEPC = false;
-     m_useAuxCorrEPC = false;
-     m_useRel = false;
-     m_useDKH = false;
-     m_rel = ZORA;
-     m_DKHOrder = 0;
+//     m_useEPC = false;
+//     m_useAuxEPC = false;
+//     m_useAuxCorrEPC = false;
+//     m_useRel = false;
+//     m_useDKH = false;
+//     m_rel = ZORA;
+//     m_DKHOrder = 0;
 }
 QString OrcaBasisData::getBasisTxt()
 {
     // Translate the enum basis set to normal text
-    // enum basisType {SVP, TZVP, TZVPP, QZVP }
+    // enum basisType {SVP, TZVP, TZVPP, QZVPP }
 
     QString returnBasis = m_enumBasis.valueToKey(m_basis);
     returnBasis.prepend("def2-");
+//    if (m_useEPC && !m_useRel) {
+//        returnBasis.append("-AE");
+//    }
     return returnBasis;
 
 }
@@ -249,41 +253,44 @@ QString OrcaBasisData::getAuxBasisTxt()
 {
     // Translate the enum basis set to normal text
     // used as auxilary basis
-    // enum basisType {SVP, TZVP, TZVPP, QZVP }
+    // enum basisType {SVP, TZVP, TZVPP, QZVPP }
 
-    QString returnBasis = m_enumBasis.valueToKey(m_auxBasis);
-    returnBasis.prepend("def2-");
-    returnBasis.append("/J");
-    return returnBasis;
+//    QString returnBasis = m_enumBasis.valueToKey(m_auxBasis);
+//    returnBasis.prepend("def2-");
+//    if (m_useEPC || m_useRel) {
+//        returnBasis.append("-AE");
+//    }
+//    returnBasis.append("/J");
+//    return returnBasis;
+    return "def2/J";
 }
 
 QString OrcaBasisData::getAuxCorrBasisTxt()
 {
     // Translate the enum basis set to normal text
     // used as correlation auxilary basis
-    // enum basisType {SVP, TZVP, TZVPP, QZVP }
+    // enum basisType {SVP, TZVP, TZVPP, QZVPP }
 
     QString returnBasis = m_enumBasis.valueToKey(m_auxCorrBasis);
     returnBasis.prepend("def2-");
     returnBasis.append("/C");
     return returnBasis;
+
 }
 
-QString OrcaBasisData::getRelTxt ()
-{
+//QString OrcaBasisData::getRelTxt ()
+//{
 
-    switch (m_rel)
-    {
-    case ZORA:
-        return "ZORA";
-    case IORA:
-        return "IORA";
-    case DKH:
-        return "DKH";
-    default:
-        return "";
-    }
-}
+//    switch (m_rel)
+//    {
+//    case ZORA:
+//        return "ZORA";
+//    case DKH:
+//        return "DKH";
+//    default:
+//        return "";
+//    }
+//}
 OrcaControlData::OrcaControlData()
 {
     m_multiplicity = 1;
@@ -492,10 +499,10 @@ QString OrcaDataData::getFormatTxt()
 {
     switch (m_coordsType)
     {
-    case ZMATRIX:
-        return "z-Matrix";
     case CARTESIAN:
         return "Cartesian";
+    case INTERNAL_COORDS:
+        return "Internal";
     case ZMATRIX_COMPACT:
         return "z-Matrix compact";
     default:

--- a/libavogadro/src/extensions/orca/orcadata.h
+++ b/libavogadro/src/extensions/orca/orcadata.h
@@ -49,14 +49,14 @@ namespace Avogadro {
 
 enum calculationType {SP, OPT, FREQ};
 enum methodType {RHF, DFT, MP2, CCSD};
-enum relType {ZORA, IORA, DKH};
+//enum relType {ZORA, DKH};
 enum accType {NORMALSCF, TIGHTSCF, VERYTIGHTSCF, EXTREMESCF};
 enum scfType {RKS, UKS};
 enum convType {DIIS, KDIIS};
 enum conv2ndType {SOSCF, NRSCF, AHSCF};
 
 
-enum coordType {CARTESIAN, ZMATRIX, ZMATRIX_COMPACT };
+enum coordType {CARTESIAN, INTERNAL_COORDS, ZMATRIX_COMPACT };
 enum printType {NOTHING, MINI, SMALL, NORMAL, LARGE};
 
 
@@ -194,35 +194,35 @@ public:
 
 
     // EPC
-    void setEPCChecked (bool value) {m_useEPC = value;}
-    bool EPCEnabled() {return m_useEPC;}
+//    void setEPCChecked (bool value) {m_useEPC = value;}
+//    bool EPCEnabled() {return m_useEPC;}
 
-    // Aux EPC
+//    // Aux EPC
 
-    void setAuxEPCChecked (bool value) {m_useAuxEPC = value;}
-    bool auxEPCEnabled() {return m_useAuxEPC;}
+//    void setAuxEPCChecked (bool value) {m_useAuxEPC = value;}
+//    bool auxEPCEnabled() {return m_useAuxEPC;}
 
 
-    // Correlation Aux EPC
+//    // Correlation Aux EPC
 
-    void setAuxCorrEPCChecked (bool value) {m_useAuxCorrEPC = value;}
-    bool auxCorrEPCEnabled() {return m_useAuxCorrEPC;}
+//    void setAuxCorrEPCChecked (bool value) {m_useAuxCorrEPC = value;}
+//    bool auxCorrEPCEnabled() {return m_useAuxCorrEPC;}
 
     // Relativistic
 
-    void setRelChecked (bool n) {m_useRel = n;}
-    bool relEnabled() {return m_useRel;}
+//    void setRelChecked (bool n) {m_useRel = n;}
+//    bool relEnabled() {return m_useRel;}
 
-    void setDKHChecked (bool n) {m_useDKH = n;}
-    bool dkhEnabled () {return m_useDKH;}
+//    void setDKHChecked (bool n) {m_useDKH = n;}
+//    bool dkhEnabled () {return m_useDKH;}
 
-    void setRel(int n) {m_rel = relType (n);}
-    void setRel (relType n) {m_rel = n;}
-    relType getRel () {return m_rel;}
-    QString getRelTxt ();
+//    void setRel(int n) {m_rel = relType (n);}
+//    void setRel (relType n) {m_rel = n;}
+//    relType getRel () {return m_rel;}
+//    QString getRelTxt ();
 
-    void setDKHOrder(int n){m_DKHOrder = n;}
-    int getDKHOrder(){return m_DKHOrder;}
+//    void setDKHOrder(int n){m_DKHOrder = n;}
+//    int getDKHOrder(){return m_DKHOrder;}
 
     // reset to default values
 
@@ -235,14 +235,14 @@ private:
     OrcaExtension::basisType m_auxBasis;
     OrcaExtension::basisType m_auxCorrBasis;
 
-    bool m_useEPC;
-    bool m_useAuxEPC;
-    bool m_useAuxCorrEPC;
+//    bool m_useEPC;
+//    bool m_useAuxEPC;
+//    bool m_useAuxCorrEPC;
 
-    bool m_useRel;
-    bool m_useDKH;
-    relType m_rel;
-    int m_DKHOrder;
+//    bool m_useRel;
+//    bool m_useDKH;
+//    relType m_rel;
+//    int m_DKHOrder;
 };
 
 class OrcaControlData {

--- a/libavogadro/src/extensions/orca/orcaextension.cpp
+++ b/libavogadro/src/extensions/orca/orcaextension.cpp
@@ -71,7 +71,6 @@ namespace Avogadro {
 
       }
 
-
     // This block sets the text for menu entry
       QAction *action = new QAction(this);
       // Wrap all user visible strings in tr() so they can be translated
@@ -108,11 +107,12 @@ namespace Avogadro {
           // Create the dialog if needed
           if (!m_dialog) {
               m_dialog = new OrcaInputDialog(qobject_cast<QWidget*>(parent()));
+
+              if (m_molecule) {
+                  m_dialog->setMolecule(m_molecule);
+              }
+              m_dialog->setWindowTitle("Orca Input Parameters");
           }
-          if (m_molecule) {
-              m_dialog->setMolecule(m_molecule);
-          }
-          m_dialog->setWindowTitle("Orca Input Parameters");
           m_dialog->show();
 
           break;
@@ -139,6 +139,8 @@ namespace Avogadro {
     void OrcaExtension::setMolecule(Molecule *molecule)
     {
         m_molecule = molecule;
+        if (m_dialog)
+            m_dialog->setMolecule(molecule);
     }
 }
 //// Include Qt moc'd headers

--- a/libavogadro/src/extensions/orca/orcaextension.h
+++ b/libavogadro/src/extensions/orca/orcaextension.h
@@ -77,7 +77,7 @@ namespace Avogadro {
 
     enum DFTFunctionalType {LDA, BP, BLYP, PW91, B3LYP, B3PW, PBEO, TPSS, TPSSH, M06L};
     enum DFTNoCosXType {NoBP, NoBLYP, NoPW91, NoTPSS};
-    enum basisType {SVP, TZVP, TZVPP, QZVP};
+    enum basisType {SVP, TZVP, TZVPP, QZVPP};
     enum gridType {Default, None, Grid3, Grid4, Grid5, Grid6, Grid7, Grid8};
     enum finalgridType {fDefault, fNone, fGrid4, fGrid5, fGrid6, fGrid7, fGrid8, fGrid9};
 

--- a/libavogadro/src/extensions/orca/orcainputdialog.cpp
+++ b/libavogadro/src/extensions/orca/orcainputdialog.cpp
@@ -106,7 +106,7 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
         auxNeeded = false;
     }
     ui.basisAuxBasisSetCombo->setEnabled(auxNeeded);
-    ui.basisAuxECPCheck->setEnabled(false);
+//    ui.basisAuxECPCheck->setEnabled(false);
 
     bool auxCorrNeeded;
     if (controlData->mp2Enabled() || controlData->ccsdEnabled()) {
@@ -115,7 +115,7 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
         auxCorrNeeded = false;
     }
     ui.basisAuxCorrBasisSetCombo->setEnabled(auxCorrNeeded);
-    ui.basisAuxCorrECPCheck->setEnabled(false);
+//    ui.basisAuxCorrECPCheck->setEnabled(false);
     m_basic = true;
     m_advanced = false;
 }
@@ -149,12 +149,12 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
       connect (ui.basisBasisSetCombo, SIGNAL(currentIndexChanged(int)), this,  SLOT (setBasisBasisSet(int )));
       connect (ui.basisAuxBasisSetCombo, SIGNAL(currentIndexChanged(int)), this, SLOT( setBasisAuxBasisSet (int )));
       connect (ui.basisAuxCorrBasisSetCombo, SIGNAL(currentIndexChanged(int)), this, SLOT( setBasisAuxCorrBasisSet (int )));
-      connect (ui.basisECPCheck, SIGNAL(toggled(bool)), this, SLOT(setBasisUseEPC (bool )));
-      connect (ui.basisAuxECPCheck, SIGNAL(toggled (bool)), this, SLOT( setBasisUseAuxEPC (bool )));
-      connect (ui.basisAuxCorrECPCheck, SIGNAL(toggled (bool)), this, SLOT( setBasisUseAuxCorrEPC (bool )));
-      connect (ui.basisRelativisticGroup, SIGNAL(toggled(bool)), this, SLOT(setBasisUseRel(bool)));
-      connect (ui.basisRelativisticCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(setBasisRel(int )));
-      connect (ui.basisDKHSpin, SIGNAL(valueChanged(int)), this, SLOT(setBasisDKHOrder(int)));
+//      connect (ui.basisECPCheck, SIGNAL(toggled(bool)), this, SLOT(setBasisUseEPC (bool )));
+//      connect (ui.basisAuxECPCheck, SIGNAL(toggled (bool)), this, SLOT( setBasisUseAuxEPC (bool )));
+//      connect (ui.basisAuxCorrECPCheck, SIGNAL(toggled (bool)), this, SLOT( setBasisUseAuxCorrEPC (bool )));
+//      connect (ui.basisRelativisticGroup, SIGNAL(toggled(bool)), this, SLOT(setBasisUseRel(bool)));
+//      connect (ui.basisRelativisticCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(setBasisRel(int )));
+//      connect (ui.basisDKHSpin, SIGNAL(valueChanged(int)), this, SLOT(setBasisDKHOrder(int)));
 
       // Advanced Control Slots
       connect(ui.advancedTree, SIGNAL(clicked(QModelIndex)), this, SLOT(advancedItemClicked(QModelIndex)));
@@ -262,14 +262,13 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
       ui.advancedStacked->setCurrentIndex(i);
   }
 
-  void OrcaInputDialog::initComboboxes()
+void  OrcaInputDialog::initComboboxes()
   {
       meta = new QMetaObject (OrcaExtension::staticMetaObject);
       QStringList items;
       for (int i=0; i < meta->enumeratorCount(); ++i) {
           items.clear();
           QMetaEnum m = meta->enumerator(i);
-          qDebug() << "//" << m.name() << "//";
           QString enumType = m.name();
           if (enumType == "DFTFunctionalType") {
               dftData->setEnumDFT(m);
@@ -286,15 +285,17 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
                   items[j].prepend("def2-");
               }
               ui.basicBasisSetCombo->addItems(items);
+
               ui.basisBasisSetCombo->addItems(items);
-              for (int j=0; j<items.size();j++) {
-                  items[j].append("/J");
+
+              for (int j=0; j<m.keyCount();j++) {
+                  items[j].append("/C");
               }
-              ui.basisAuxBasisSetCombo->addItems(items);
-
-              items.replaceInStrings("/J", "/C");
-
               ui.basisAuxCorrBasisSetCombo->addItems(items);
+
+              items.clear();
+              items << "def2/J";
+              ui.basisAuxBasisSetCombo->addItems(items);   // Only one aux-basisset available
           } else if (enumType == "gridType") {
 
               dftData->setEnumGrid(m);
@@ -340,16 +341,16 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
       ui.basisBasisSetCombo->setCurrentIndex(basisData->getBasis());
       ui.basisAuxBasisSetCombo->setCurrentIndex(basisData->getAuxBasis());
       ui.basisAuxCorrBasisSetCombo->setCurrentIndex(basisData->getAuxCorrBasis());
+      ui.basisRelativisticGroup->hide();
+//      ui.basisECPCheck->setChecked(basisData->EPCEnabled());
+//      ui.basisAuxECPCheck->setChecked(basisData->auxEPCEnabled());
+//      ui.basisAuxCorrECPCheck->setChecked(basisData->auxCorrEPCEnabled());
 
-      ui.basisECPCheck->setChecked(basisData->EPCEnabled());
-      ui.basisAuxECPCheck->setChecked(basisData->auxEPCEnabled());
-      ui.basisAuxCorrECPCheck->setChecked(basisData->auxCorrEPCEnabled());
-
-      ui.basisRelativisticGroup->setChecked(basisData->relEnabled());
-      ui.basisRelativisticCombo->setEnabled(basisData->relEnabled());
-      ui.basisRelativisticCombo->setCurrentIndex(basisData->getRel());
-      ui.basisDKHSpin->setVisible(basisData->dkhEnabled());
-      ui.basisDKHLabel->setVisible(basisData->dkhEnabled());
+//      ui.basisRelativisticGroup->setChecked(basisData->relEnabled());
+//      ui.basisRelativisticCombo->setEnabled(basisData->relEnabled());
+//      ui.basisRelativisticCombo->setCurrentIndex(basisData->getRel());
+//      ui.basisDKHSpin->setVisible(basisData->dkhEnabled());
+//      ui.basisDKHLabel->setVisible(basisData->dkhEnabled());
   }
 
   void OrcaInputDialog::initControlData()
@@ -490,10 +491,14 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
   {
       // Disconnect the old molecule first...
 
+//      qDebug() << " molecule = " << molecule;
+//      cout  << "m_molecule = " << m_molecule<< endl;
       if (m_molecule)
         disconnect(m_molecule, 0, this, 0);
 
       m_molecule = molecule;
+
+      cout  << "m_molecule = " << m_molecule<< endl;
 
       // Set multiplicity to the OB value
 
@@ -631,63 +636,63 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
       updateAdvancedSetup();
   }
 
-  void OrcaInputDialog::setBasisUseEPC(bool value)
-  {
-      basisData->setEPCChecked(value);
-      basisData->setAuxEPCChecked (value);
-      basisData->setAuxCorrEPCChecked (value);
-      updateAdvancedSetup();
+//  void OrcaInputDialog::setBasisUseEPC(bool value)
+//  {
+//      basisData->setEPCChecked(value);
+////      basisData->setAuxEPCChecked (value);
+////      basisData->setAuxCorrEPCChecked (value);
+//      updateAdvancedSetup();
 
-  }
-  void OrcaInputDialog::setBasisUseAuxEPC (bool value)
-  {
-      basisData->setAuxEPCChecked (value);
-      updateAdvancedSetup();
-  }
+//  }
+//  void OrcaInputDialog::setBasisUseAuxEPC (bool value)
+//  {
+//      basisData->setAuxEPCChecked (value);
+//      updateAdvancedSetup();
+//  }
 
-  void OrcaInputDialog::setBasisUseAuxCorrEPC (bool value)
-  {
-      basisData->setAuxCorrEPCChecked (value);
-      updateAdvancedSetup();
-  }
-  void OrcaInputDialog::setBasisUseRel(bool value)
-  {
-      basisData->setRelChecked(value);
-      if (value) {
-          ui.basisRelativisticCombo->setEnabled(true);
-          if (basisData->dkhEnabled()) {
-              ui.basisDKHSpin->setVisible(true);
-              ui.basisDKHLabel->setVisible(true);
-          }
-      } else {
-          ui.basisDKHSpin->setVisible(false);
-          ui.basisDKHLabel->setVisible(false);
-      }
-      updateAdvancedSetup();
-  }
+//  void OrcaInputDialog::setBasisUseAuxCorrEPC (bool value)
+//  {
+//      basisData->setAuxCorrEPCChecked (value);
+//      updateAdvancedSetup();
+//  }
+//  void OrcaInputDialog::setBasisUseRel(bool value)
+//  {
+//      basisData->setRelChecked(value);
+//      if (value) {
+//          ui.basisRelativisticCombo->setEnabled(true);
+//          if (basisData->dkhEnabled()) {
+//              ui.basisDKHSpin->setVisible(true);
+//              ui.basisDKHLabel->setVisible(true);
+//          }
+//      } else {
+//          ui.basisDKHSpin->setVisible(false);
+//          ui.basisDKHLabel->setVisible(false);
+//      }
+//      updateAdvancedSetup();
+//  }
 
-  void OrcaInputDialog::setBasisRel(int n)
-  {
-      basisData->setRel(n);
-      if (n == DKH) {
-          basisData->setDKHChecked(true);
-          ui.basisDKHSpin->setVisible(true);
-          ui.basisDKHLabel->setVisible(true);
-      } else {
-          basisData->setDKHChecked(false);
-          ui.basisDKHSpin->setVisible(false);
-          ui.basisDKHLabel->setVisible(false);
-      }
+//  void OrcaInputDialog::setBasisRel(int n)
+//  {
+//      basisData->setRel(n);
+//      if (n == DKH) {
+//          basisData->setDKHChecked(true);
+//          ui.basisDKHSpin->setVisible(true);
+//          ui.basisDKHLabel->setVisible(true);
+//      } else {
+//          basisData->setDKHChecked(false);
+//          ui.basisDKHSpin->setVisible(false);
+//          ui.basisDKHLabel->setVisible(false);
+//      }
 
-      updateAdvancedSetup();
-  }
+//      updateAdvancedSetup();
+//  }
 
 
-  void OrcaInputDialog::setBasisDKHOrder(int n)
-  {
-      basisData->setDKHOrder(n);
-      updateAdvancedSetup();
-  }
+//  void OrcaInputDialog::setBasisDKHOrder(int n)
+//  {
+//      basisData->setDKHOrder(n);
+//      updateAdvancedSetup();
+//  }
 
 //
 // Set Advanced Control Widgets
@@ -746,7 +751,6 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
       QStringList noRijCosXDFT;
       for (int i=0; i < meta.enumeratorCount(); ++i) {
           QMetaEnum m = meta.enumerator(i);
-          qDebug() << "//" << m.name() << "//";
           QString enumType = m.name();
           if (enumType == "DFTNoCosXType") {
               for (int j=0; j<m.keyCount();j++) {
@@ -1077,7 +1081,7 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
           charge = controlData->getCharge();
           multiplicity = controlData->getMultiplicity();
 
-          mol << "## avogadro generated ORCA input file \n# Advanced Mode\n";
+          mol << "# avogadro generated ORCA input file \n# Advanced Mode\n";
 
           // write the comment / comment
 
@@ -1109,7 +1113,10 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
 
           // Basis Set(s)
 
-          mol <<  basisData->getBasisTxt() << " ";
+//          if (basisData->relEnabled()) {
+//              mol <<  basisData->getRelTxt() << "-" ;
+//          }
+          mol << basisData->getBasisTxt() << " ";
 
           if (controlData->cosXEnabled() || controlData->dftEnabled()) {
               mol << basisData->getAuxBasisTxt() << " ";
@@ -1117,16 +1124,16 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
           if (controlData->mp2Enabled()) {
               mol << basisData->getAuxCorrBasisTxt() << " ";
           }
-          if (basisData->EPCEnabled()) {
-              mol << "EPC{" << basisData->getBasisTxt();
-              if (controlData->cosXEnabled() || controlData->dftEnabled()) {
-                  mol  << "," << basisData->getAuxBasisTxt();
-              }
-              if (controlData->mp2Enabled()) {
-                  mol << "," << basisData->getAuxCorrBasisTxt();
-              }
-              mol << "} ";
-          }
+//          if (basisData->EPCEnabled()) {
+//              mol << "EPC{" << basisData->getBasisTxt();
+//              if (controlData->cosXEnabled() || controlData->dftEnabled()) {
+//                  mol  << "," << basisData->getAuxBasisTxt();
+//              }
+//              if (controlData->mp2Enabled()) {
+//                  mol << "," << basisData->getAuxCorrBasisTxt();
+//              }
+//              mol << "} ";
+//          }
           if (dataData->getPrintLevel() != 0) {
               mol << dataData->getPrintLevelTxt() << " ";
           }
@@ -1138,13 +1145,13 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
               mol << cosXData->getGridTxt() << " " << cosXData->getFinalGridTxt() << " ";
           }
           mol << scfData->getAccuracyTxt() << " ";
-          if (basisData->relEnabled()) {
-              if (basisData->dkhEnabled()){
-                  mol << basisData->getRelTxt() << basisData->getDKHOrder() << " ";
-              } else {
-                  mol << basisData->getRelTxt() << " ";
-              }
-          }
+//          if (basisData->relEnabled()) {
+////              if (basisData->dkhEnabled()){
+////                  mol << basisData->getRelTxt() << basisData->getDKHOrder() << " ";
+////              } else {
+//                  mol << basisData->getRelTxt() << " ";
+////              }
+//          }
           // SCF Block Infos
 
           mol << "\n";
@@ -1216,77 +1223,76 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
           }
           mol << "*\n";
 
-      } else if (m_molecule && (formatCheck == ZMATRIX)) {
+//      } else if (m_molecule && (formatCheck == ZMATRIX)) {
 
-          // Z-matrix
+//          // Z-matrix
 
-          QTextStream mol(&buffer);
-          mol.setFieldAlignment(QTextStream::AlignAccountingStyle);
-          mol << "* int " << charge << " " << multiplicity << "\n";
-          OBAtom *a, *b, *c;
-          double r, w, t;
+//          QTextStream mol(&buffer);
+//          mol.setFieldAlignment(QTextStream::AlignAccountingStyle);
+//          mol << "*int " << charge << " " << multiplicity << "\n";
+//          OBAtom *a, *b, *c;
+//          double r, w, t;
 
-          /* Taken from OpenBabel's gzmat file format converter */
-          std::vector<OBInternalCoord*> vic;
-          vic.push_back((OpenBabel::OBInternalCoord*)NULL);
-          OpenBabel::OBMol obmol = m_molecule->OBMol();
-          FOR_ATOMS_OF_MOL(atom, &obmol)
-                  vic.push_back(new OpenBabel::OBInternalCoord);
+//          /* Taken from OpenBabel's gzmat file format converter */
+//          std::vector<OBInternalCoord*> vic;
+//          vic.push_back((OpenBabel::OBInternalCoord*)NULL);
+//          OpenBabel::OBMol obmol = m_molecule->OBMol();
+//          FOR_ATOMS_OF_MOL(atom, &obmol)
+//                  vic.push_back(new OpenBabel::OBInternalCoord);
 
-          CartesianToInternal(vic, obmol);
+//          CartesianToInternal(vic, obmol);
 
-          FOR_ATOMS_OF_MOL(atom, &obmol)
-          {
-              a = vic[atom->GetIdx()]->_a;
-              b = vic[atom->GetIdx()]->_b;
-              c = vic[atom->GetIdx()]->_c;
+//          FOR_ATOMS_OF_MOL(atom, &obmol)
+//          {
+//              a = vic[atom->GetIdx()]->_a;
+//              b = vic[atom->GetIdx()]->_b;
+//              c = vic[atom->GetIdx()]->_c;
 
-              mol << qSetFieldWidth(3) << QString(etab.GetSymbol(atom->GetAtomicNum()));
+//              mol << qSetFieldWidth(3) << QString(etab.GetSymbol(atom->GetAtomicNum()));
 
-              if (atom->GetIdx() > 1)
-                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(a->GetIdx())
-                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("r") + QString::number(atom->GetIdx());
+//              if (atom->GetIdx() > 1)
+//                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(a->GetIdx())
+//                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("r") + QString::number(atom->GetIdx());
 
-              if (atom->GetIdx() > 2)
-                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(b->GetIdx())
-                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("a") + QString::number(atom->GetIdx());
+//              if (atom->GetIdx() > 2)
+//                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(b->GetIdx())
+//                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("a") + QString::number(atom->GetIdx());
 
-              if (atom->GetIdx() > 3)
-                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(c->GetIdx())
-                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("d") + QString::number(atom->GetIdx());
+//              if (atom->GetIdx() > 3)
+//                  mol << qSetFieldWidth(0) << "  " << qSetFieldWidth(3) << QString::number(c->GetIdx())
+//                      << qSetFieldWidth(0) << "  "<< qSetFieldWidth(4) << QString("d") + QString::number(atom->GetIdx());
 
-              mol << qSetFieldWidth(0) << '\n';
-          }
+//              mol << qSetFieldWidth(0) << '\n';
+//          }
 
-          mol << " variables\n";
-          FOR_ATOMS_OF_MOL(atom, &obmol)
-          {
-              r = vic[atom->GetIdx()]->_dst;
-              w = vic[atom->GetIdx()]->_ang;
-              if (w < 0.0)
-                  w += 360.0;
-              t = vic[atom->GetIdx()]->_tor;
-              if (t < 0.0)
-                  t += 360.0;
-              if (atom->GetIdx() > 1)
-                  mol << "   r" << atom->GetIdx() << qSetFieldWidth(15)
-                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
-                      << r << qSetFieldWidth(0) << '\n';
-              if (atom->GetIdx() > 2)
-                  mol << "   a" << atom->GetIdx() << qSetFieldWidth(15)
-                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
-                      << w << qSetFieldWidth(0) << '\n';
-              if (atom->GetIdx() > 3)
-                  mol << "   d" << atom->GetIdx() << qSetFieldWidth(15)
-                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
-                      << t << qSetFieldWidth(0) << '\n';
-          }
-          mol << " end\n";
-          foreach (OpenBabel::OBInternalCoord *c, vic)
-              delete c;
-      } else if (m_molecule && (formatCheck == ZMATRIX_COMPACT)) {
-
-          // Compact ZMatrix
+//          mol << " variables\n";
+//          FOR_ATOMS_OF_MOL(atom, &obmol)
+//          {
+//              r = vic[atom->GetIdx()]->_dst;
+//              w = vic[atom->GetIdx()]->_ang;
+//              if (w < 0.0)
+//                  w += 360.0;
+//              t = vic[atom->GetIdx()]->_tor;
+//              if (t < 0.0)
+//                  t += 360.0;
+//              if (atom->GetIdx() > 1)
+//                  mol << "   r" << atom->GetIdx() << qSetFieldWidth(15)
+//                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
+//                      << r << qSetFieldWidth(0) << '\n';
+//              if (atom->GetIdx() > 2)
+//                  mol << "   a" << atom->GetIdx() << qSetFieldWidth(15)
+//                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
+//                      << w << qSetFieldWidth(0) << '\n';
+//              if (atom->GetIdx() > 3)
+//                  mol << "   d" << atom->GetIdx() << qSetFieldWidth(15)
+//                      << qSetRealNumberPrecision(5) << forcepoint << fixed << right
+//                      << t << qSetFieldWidth(0) << '\n';
+//          }
+//          mol << " end\n";
+//          foreach (OpenBabel::OBInternalCoord *c, vic)
+//              delete c;
+      } else if (m_molecule && (formatCheck == INTERNAL_COORDS)) {
+          // Internal coordinates
 
           QTextStream mol(&buffer);
 
@@ -1317,25 +1323,83 @@ OrcaInputDialog::OrcaInputDialog(QWidget *parent, Qt::WindowFlags f ) :
                   t += 360.0;
 
               mol << qSetFieldWidth(4) << right
-                  << QString(etab.GetSymbol(atom->GetAtomicNum())
-                             + QString::number(atom->GetIdx()));
+                  << QString(etab.GetSymbol(atom->GetAtomicNum()));
+
+              if (a) {
+                  mol << qSetFieldWidth(6) << right << QString::number(a->GetIdx());
+              } else {
+                  mol << qSetFieldWidth(6) << right << "0" ;
+              }
+              if (b) {
+                  mol << qSetFieldWidth(6) << right << QString::number(b->GetIdx());
+              } else {
+                  mol << qSetFieldWidth(6) << right << "0" ;
+              }
+              if (c) {
+                  mol << qSetFieldWidth(6) << right << QString::number(c->GetIdx());
+              } else {
+                  mol << qSetFieldWidth(6) << right << "0" ;
+              }
+              mol << qSetFieldWidth(15) << qSetRealNumberPrecision(5) << forcepoint << fixed << right << r;
+              mol << qSetFieldWidth(15) << qSetRealNumberPrecision(5) << forcepoint << fixed << right << w;
+              mol << qSetFieldWidth(15) << qSetRealNumberPrecision(5) << forcepoint << fixed << right << t;
+
+              mol << qSetFieldWidth(0) << '\n';
+          }
+          mol << "*\n";
+
+          foreach (OpenBabel::OBInternalCoord *c, vic)
+              delete c;
+
+      } else if (m_molecule && (formatCheck == ZMATRIX_COMPACT)) {
+//          // Compact ZMatrix
+
+          QTextStream mol(&buffer);
+
+          mol << "* gzmt " << charge << " " << multiplicity << "\n";
+
+          OBAtom *a, *b, *c;
+          double r, w, t;
+
+          /* Taken from OpenBabel's gzmat file format converter */
+          std::vector<OBInternalCoord*> vic;
+          vic.push_back((OpenBabel::OBInternalCoord*)NULL);
+          OpenBabel::OBMol obmol = m_molecule->OBMol();
+          FOR_ATOMS_OF_MOL(atom, &obmol)
+                  vic.push_back(new OpenBabel::OBInternalCoord);
+          CartesianToInternal(vic, obmol);
+
+          FOR_ATOMS_OF_MOL(atom, &obmol)
+          {
+              a = vic[atom->GetIdx()]->_a;
+              b = vic[atom->GetIdx()]->_b;
+              c = vic[atom->GetIdx()]->_c;
+              r = vic[atom->GetIdx()]->_dst;
+              w = vic[atom->GetIdx()]->_ang;
+              if (w < 0.0)
+                  w += 360.0;
+              t = vic[atom->GetIdx()]->_tor;
+              if (t < 0.0)
+                  t += 360.0;
+
+              mol << qSetFieldWidth(4) << right
+                  << QString(etab.GetSymbol(atom->GetAtomicNum()));
               if (atom->GetIdx() > 1)
                   mol << qSetFieldWidth(6) << right
-                      << QString(etab.GetSymbol(a->GetAtomicNum())
-                                 + QString::number(a->GetIdx())) << qSetFieldWidth(15)
+                      << QString::number(a->GetIdx()) << qSetFieldWidth(15)
                       << qSetRealNumberPrecision(5) << forcepoint << fixed << right << r;
               if (atom->GetIdx() > 2)
                   mol << qSetFieldWidth(6) << right
-                      << QString(etab.GetSymbol(b->GetAtomicNum())
-                                 + QString::number(b->GetIdx())) << qSetFieldWidth(15)
+                      << QString::number(b->GetIdx()) << qSetFieldWidth(15)
                       << qSetRealNumberPrecision(5) << forcepoint << fixed << right << w;
               if (atom->GetIdx() > 3)
                   mol << qSetFieldWidth(6) << right
-                      << QString(etab.GetSymbol(c->GetAtomicNum())
-                                 + QString::number(c->GetIdx())) << qSetFieldWidth(15)
+                      << QString::number(c->GetIdx()) << qSetFieldWidth(15)
                       << qSetRealNumberPrecision(5) << forcepoint << fixed << right << t;
               mol << qSetFieldWidth(0) << '\n';
           }
+          mol << "*\n";
+
           foreach (OpenBabel::OBInternalCoord *c, vic)
               delete c;
       }

--- a/libavogadro/src/extensions/orca/orcainputdialog.h
+++ b/libavogadro/src/extensions/orca/orcainputdialog.h
@@ -100,13 +100,13 @@ namespace Avogadro {
         void setBasisBasisSet(int n);
         void setBasisAuxBasisSet (int n);
         void setBasisAuxCorrBasisSet(int n);
-        void setBasisUseEPC (bool value);
-        void setBasisUseAuxEPC (bool value);
-        void setBasisUseAuxCorrEPC (bool value);
+//        void setBasisUseEPC (bool value);
+//        void setBasisUseAuxEPC (bool value);
+//        void setBasisUseAuxCorrEPC (bool value);
 
-        void setBasisUseRel (bool value);
-        void setBasisRel (int n);
-        void setBasisDKHOrder (int n);
+//        void setBasisUseRel (bool value);
+//        void setBasisRel (int n);
+//        void setBasisDKHOrder (int n);
 
         // Advanced Control Slots
 

--- a/libavogadro/src/extensions/orca/orcainputdialog.ui
+++ b/libavogadro/src/extensions/orca/orcainputdialog.ui
@@ -278,7 +278,7 @@
             </item>
             <item>
              <property name="text">
-              <string>z-Matrix</string>
+              <string>Internal</string>
              </property>
             </item>
             <item>
@@ -413,7 +413,7 @@
         <bool>true</bool>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="basisSetPage">
         <widget class="QGroupBox" name="basisBasisGroup">
@@ -439,19 +439,6 @@
           </property>
           <property name="sizeAdjustPolicy">
            <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-         <widget class="QCheckBox" name="basisECPCheck">
-          <property name="geometry">
-           <rect>
-            <x>162</x>
-            <y>41</y>
-            <width>56</width>
-            <height>24</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>ECP</string>
           </property>
          </widget>
         </widget>
@@ -480,19 +467,6 @@
            <enum>QComboBox::AdjustToContents</enum>
           </property>
          </widget>
-         <widget class="QCheckBox" name="basisAuxECPCheck">
-          <property name="geometry">
-           <rect>
-            <x>168</x>
-            <y>40</y>
-            <width>97</width>
-            <height>24</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Aux. ECP</string>
-          </property>
-         </widget>
         </widget>
         <widget class="QGroupBox" name="basisRelativisticGroup">
          <property name="geometry">
@@ -517,7 +491,7 @@
            <rect>
             <x>12</x>
             <y>36</y>
-            <width>207</width>
+            <width>97</width>
             <height>33</height>
            </rect>
           </property>
@@ -531,31 +505,9 @@
              </item>
              <item>
               <property name="text">
-               <string>IORA</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
                <string>DKH</string>
               </property>
              </item>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="basisDKHLabel">
-             <property name="text">
-              <string>Order</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="basisDKHSpin">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>5</number>
-             </property>
             </widget>
            </item>
           </layout>
@@ -584,19 +536,6 @@
           </property>
           <property name="sizeAdjustPolicy">
            <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-         <widget class="QCheckBox" name="basisAuxCorrECPCheck">
-          <property name="geometry">
-           <rect>
-            <x>168</x>
-            <y>40</y>
-            <width>100</width>
-            <height>24</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Corr. ECP</string>
           </property>
          </widget>
         </widget>
@@ -692,8 +631,8 @@
           <rect>
            <x>122</x>
            <y>19</y>
-           <width>217</width>
-           <height>25</height>
+           <width>189</width>
+           <height>27</height>
           </rect>
          </property>
          <property name="sizeAdjustPolicy">
@@ -734,7 +673,7 @@
            <x>18</x>
            <y>222</y>
            <width>130</width>
-           <height>27</height>
+           <height>29</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -763,7 +702,7 @@
            <x>180</x>
            <y>222</y>
            <width>161</width>
-           <height>27</height>
+           <height>29</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_17">
@@ -868,7 +807,7 @@
             </item>
             <item>
              <property name="text">
-              <string>z-Matrix</string>
+              <string>Internal</string>
              </property>
             </item>
             <item>

--- a/libavogadro/src/extensions/quantuminput/gaussianinputdialog.cpp
+++ b/libavogadro/src/extensions/quantuminput/gaussianinputdialog.cpp
@@ -173,6 +173,8 @@ namespace Avogadro
 
   void GaussianInputDialog::setMolecule(Molecule *molecule)
   {
+      qDebug() << " molecule = " << molecule;
+      qDebug() << "m_molecule = " << m_molecule;
     // Disconnect the old molecule first...
     if (m_molecule) {
       disconnect(m_molecule, 0, this, 0);

--- a/libavogadro/src/extensions/spectra/CMakeLists.txt
+++ b/libavogadro/src/extensions/spectra/CMakeLists.txt
@@ -11,5 +11,5 @@ avogadro_plugin_nogl(vibrationextension
 
 ### Spectra
 avogadro_plugin_nogl(spectraextension
-  "spectraextension.cpp;spectradialog.cpp;spectratype.cpp;abstract_ir.cpp;ir.cpp;nmr.cpp;dos.cpp;uv.cpp;cd.cpp;raman.cpp"
-  "spectradialog.ui;tab_ir_raman.ui;tab_nmr.ui;tab_dos.ui;tab_uv.ui;tab_cd.ui")
+  "spectraextension.cpp;spectradialog.cpp;spectratype.cpp;abstract_ir.cpp;ir.cpp;nmr.cpp;dos.cpp;uv.cpp;cd.cpp;raman.cpp;xray_em.cpp;xray_abs.cpp;abstract_xray.cpp"
+  "spectradialog.ui;tab_ir_raman.ui;tab_nmr.ui;tab_dos.ui;tab_uv.ui;tab_cd.ui;tab_xray.ui")

--- a/libavogadro/src/extensions/spectra/abstract_ir.h
+++ b/libavogadro/src/extensions/spectra/abstract_ir.h
@@ -29,6 +29,7 @@ namespace Avogadro {
     
   enum ScalingType { LINEAR, RELATIVE };
 
+
   // Abstract data type - no instance of it can be created
   class AbstractIRSpectra : public SpectraType
   {
@@ -51,6 +52,7 @@ namespace Avogadro {
     void fwhmSliderPressed();
     void fwhmSliderReleased();    
     void changeScalingType(int);
+    void changeLineShape(int);
     void updateYAxis(QString);
     void rescaleFrequencies();
 
@@ -64,6 +66,8 @@ namespace Avogadro {
     QString m_yaxis;
     QList<double> m_xList_orig;
     ScalingType m_scalingType;
+    LineShape m_lineShape;         // gaussian or lorentzian peaks
+    int m_nPoints;                 // number of points of gaussian/lorentzian pulse
   };
 }
 

--- a/libavogadro/src/extensions/spectra/abstract_xray.cpp
+++ b/libavogadro/src/extensions/spectra/abstract_xray.cpp
@@ -1,0 +1,423 @@
+/**********************************************************************
+  SpectraDialog - Visualize spectral data from QM calculations
+
+  Copyright (C) 2009 by David Lonie
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Library General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ ***********************************************************************/
+
+#include <openbabel/generic.h>
+
+#include "abstract_xray.h"
+
+#include <QtGui/QMessageBox>
+#include <QtCore/QDebug>
+
+#include <openbabel/mol.h>
+
+using namespace std;
+
+namespace Avogadro {
+
+AbstractXRaySpectra::AbstractXRaySpectra( SpectraDialog *parent ) :
+    SpectraType( parent ),m_lineShape(GAUSSIAN), m_nPoints(10)
+{
+    ui.setupUi(m_tab_widget);
+    // Setup signals/slots
+    connect(this, SIGNAL(plotDataChanged()),
+            m_dialog, SLOT(regenerateCalculatedSpectra()));
+    connect(ui.cb_labelPeaks, SIGNAL(toggled(bool)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_FWHM, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_FWHM_Voigt, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_nPoints, SIGNAL(valueChanged(int)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_Xmin, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_Xmax, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.combo_XUnit, SIGNAL(currentIndexChanged(int)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.combo_XRayType, SIGNAL(currentIndexChanged(QString)),
+            this, SLOT(XRayTypeChanged(QString)));
+
+    connect(ui.combo_lineShape, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(changeLineShape(int)));
+
+    connect(ui.hs_EnergyShift, SIGNAL(valueChanged(int)),
+            this, SLOT(EnergyShiftSilderValueChanged(int)));
+    connect(ui.spin_EnergyShift, SIGNAL(valueChanged(double)),
+            this, SLOT(EnergyShiftSpinValueChanged(double)));
+
+    m_EnergyShift = ui.spin_EnergyShift->value();
+    m_newShift = false;
+}
+void AbstractXRaySpectra::EnergyShiftSpinValueChanged(double value)
+{
+    m_EnergyShift = value;
+    ui.hs_EnergyShift->setValue((int(m_EnergyShift)));
+    m_newShift = true;
+    emit plotDataChanged();
+}
+void AbstractXRaySpectra::EnergyShiftSilderValueChanged(int value)
+{
+    m_EnergyShift = double(value);
+    ui.spin_EnergyShift->setValue(m_EnergyShift);
+    m_newShift = true;
+    emit plotDataChanged();
+}
+
+void AbstractXRaySpectra::XRayTypeChanged(const QString & str)
+{
+     m_yList.clear();
+    int tmp_minIdx = m_XminIdx;
+    int tmp_maxIdx = m_XmaxIdx;
+    if (m_XminIdx>m_XmaxIdx) {
+        tmp_minIdx = m_XmaxIdx;
+        tmp_maxIdx = m_XminIdx;
+    }
+    qDebug() << "str = " << str << endl;
+     if (str == "Electric dipole") {
+         for (int i = tmp_minIdx; i <= tmp_maxIdx; i++){
+             m_yList.append(m_edipole.at(i));
+         }
+     } else if (str == "Electric dipole/total") {
+         for (int i = tmp_minIdx; i <= tmp_maxIdx; i++){
+             m_yList.append(m_D2.at(i));
+         }
+     } else if (str == "Magnetic dipole/total") {
+         for (int i = tmp_minIdx; i <= tmp_maxIdx; i++){
+             m_yList.append(m_M2.at(i));
+         }
+     } else if (str == "Quadrupole dipole/total") {
+         for (int i = tmp_minIdx; i <= tmp_maxIdx; i++){
+             m_yList.append(m_Q2.at(i));
+         }
+     } else if (str == "Combined") {
+         for (int i = tmp_minIdx; i <= tmp_maxIdx; i++){
+             m_yList.append(m_combined.at(i));
+         }
+     }
+    m_XRayType = str;
+    emit plotDataChanged();
+}
+//
+// choose line shape - gaussian or lorentzian
+//
+void AbstractXRaySpectra::changeLineShape(int type)
+{
+    m_lineShape = static_cast<LineShape>(type);
+    if (m_lineShape == GAUSSIAN || m_lineShape == LORENTZIAN) {
+        ui.label_FWHM_Voigt->hide();
+        ui.spin_FWHM_Voigt->hide();
+        ui.label_FWHM_peak->setText("Peak Width");
+    } else if (m_lineShape == VOIGT) {
+        ui.label_FWHM_Voigt->show();
+        ui.spin_FWHM_Voigt->show();
+        ui.label_FWHM_peak->setText("Gaussian Width");
+    }
+    emit plotDataChanged();
+}
+
+void AbstractXRaySpectra::getCalculatedPlotObject(PlotObject *plotObject){
+    plotObject->clearPoints();
+    double conv_unit[3]= {1., eV_to_nm, cm_1_to_nm};
+
+    if (ui.spin_FWHM->value() != 0.0 && ui.cb_labelPeaks->isEnabled()) {
+        ui.cb_labelPeaks->setEnabled(false);
+        ui.cb_labelPeaks->setChecked(false);
+    }
+    if (ui.spin_FWHM->value() == 0.0 && !ui.cb_labelPeaks->isEnabled()) {
+        ui.cb_labelPeaks->setEnabled(true);
+    }
+    if (!ui.cb_labelPeaks->isEnabled()) {
+        ui.cb_labelPeaks->setChecked(false);
+    }
+    // Get X units
+    m_resize = false;
+    m_newrange = false;
+    if (m_XUnit != XUnits(ui.combo_XUnit->currentIndex())) {
+        m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+        m_resize = true;
+    }
+    // Get X min
+    if (m_xmin != ui.spin_Xmin->value()) {
+        m_xmin = ui.spin_Xmin->value();
+        m_xmin_org = conv_unit[int(m_XUnit)]/m_xmin;
+        m_newrange = true;
+    }
+    // Get X max
+    if (m_xmax != ui.spin_Xmax->value()) {
+        m_xmax = ui.spin_Xmax->value();
+        m_xmax_org = conv_unit[int(m_XUnit)]/m_xmax;
+        m_newrange = true;
+    }
+    if (m_newrange || m_resize || m_newShift){
+        m_xList.clear();
+        switch (m_XUnit) {
+        case WAVELENGTH:
+            m_XmaxIdx = getXmaxIdx(WAVELENGTH);
+            m_XminIdx = getXminIdx(WAVELENGTH);
+            if (m_XmaxIdx == m_XminIdx) {         // extend to all points
+                m_XminIdx = m_wavelength.size()-1;
+                m_XmaxIdx = 0;
+            }
+            for (int i = m_XmaxIdx; i <= m_XminIdx; i++){
+                m_xList.append(m_wavelength.at(i)+m_EnergyShift);
+            }
+            rearrangeYList(m_XmaxIdx, m_XminIdx);
+            break;
+        case ENERGY_eV:
+            m_XmaxIdx = getXmaxIdx(ENERGY_eV);
+            m_XminIdx = getXminIdx(ENERGY_eV);
+            if (m_XmaxIdx == m_XminIdx) {         // extend to all points
+                m_XminIdx = 0;
+                m_XmaxIdx = m_energy.size()-1;
+            }
+            for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+                m_xList.append(m_energy.at(i)+m_EnergyShift);
+            }
+            rearrangeYList(m_XminIdx, m_XmaxIdx);
+            break;
+        case WAVENUMBER:
+            m_XmaxIdx = getXmaxIdx(WAVENUMBER);
+            m_XminIdx = getXminIdx(WAVENUMBER);
+            if (m_XmaxIdx == m_XminIdx) {         // extend to all points
+                m_XminIdx = 0;
+                m_XmaxIdx = m_wavenumber.size()-1;
+            }
+            for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+                m_xList.append(m_wavenumber.at(i)+m_EnergyShift);
+            }
+            rearrangeYList(m_XminIdx, m_XmaxIdx);
+            break;
+        default:
+            break; // never hit here
+        }
+    }
+
+    if (m_xList.size() < 1 && m_yList.size() < 1) return;
+
+    double wavelength, intensity;
+    double FWHM = ui.spin_FWHM->value();
+    m_nPoints = ui.spin_nPoints->value();
+    bool use_widening = (FWHM == 0) ? false : true;
+
+ // overlay line shapes
+
+    if (use_widening) {
+        if (m_lineShape == GAUSSIAN) {  // gaussian shape
+            // convert FWHM to sigma squared
+            double sigma = FWHM / (2.0 * sqrt(2.0 * log(2.0)));
+            double s2	= sigma*sigma;
+            // create points
+            QList<double> xPoints = getXPoints(FWHM, m_nPoints);
+            for (int i = 0; i < xPoints.size(); i++) {
+                double x = xPoints.at(i);
+                double y = 0.0;
+                for (int j = 0; j < m_yList.size(); j++) {
+                    double t = m_yList.at(j);
+                    double x0 = m_xList.at(j);
+
+                    y += t * exp( - ((x-x0)*(x-x0)/ (2 * s2) ) )/
+                            // Normalization factor: (CP, 224 (1997) 143-155)
+                             sqrt(2 * M_PI * s2);
+                }
+                plotObject->addPoint(x,y*2.87e4);  // Normalization factor: (CP, 224 (1997) 143-155)
+            }
+        } else if (m_lineShape == LORENTZIAN) {    // lorentzian shape
+            double hwhm= FWHM /2.0;
+            // create points
+            QList<double> xPoints = getXPoints(FWHM, m_nPoints);
+            for (int i = 0; i < xPoints.size(); i++) {
+                double x = xPoints.at(i);
+                double y = 0.0;
+
+                for (int j = 0; j < m_yList.size(); j++) {
+                    double t = m_yList.at(j);
+                    double x0 = m_xList.at(j);
+                    y += t * hwhm / (M_PI * ((x-x0)*(x-x0) + hwhm*hwhm));
+                }
+                plotObject->addPoint(x,y*2.87e4);   // Normalization factor: (CP, 224 (1997) 143-155)
+            }
+        }
+        else {    // Voigt shape
+                    double hwhm= ui.spin_FWHM_Voigt->value() /2.0;
+                    double sigma = FWHM / (2.0 * sqrt(2.0 * log(2.0)));
+                    double s2	= sigma*sigma;
+                    // create points
+                    QList<double> xPoints = getXPoints(FWHM, m_nPoints);
+                    for (int i = 0; i < xPoints.size(); i++) {
+                        double x = xPoints.at(i);
+                        double y = 0.0;
+
+                        for (int j = 0; j < m_yList.size(); j++) {
+                            double t = m_yList.at(j);
+                            double x0 = m_xList.at(j);
+                            y += t * exp( - ( (x-x0)*(x-x0) / (2 * s2)) ) /
+                                    sqrt(2 * M_PI * s2);
+
+                            y += t * hwhm / (M_PI * ((x-x0)*(x-x0) + hwhm*hwhm));
+                        }
+                        // 50% gaussian and 50% lorentzian part
+                        plotObject->addPoint(x,y*0.5*2.87e4);   // Normalization factor: (CP, 224 (1997) 143-155)
+                    }
+                }
+    } else {  // only points
+        for (int i = 0; i < m_yList.size(); i++) {
+
+            wavelength = m_xList.at(i);
+            intensity = m_yList.at(i) * 2.87e4;     // Normalization factor:
+
+            plotObject->addPoint ( wavelength, 0 );
+            if (ui.cb_labelPeaks->isChecked()) {
+                // %L1 uses localized number format (e.g., 1.023,4 in Europe)
+                plotObject->addPoint( wavelength, intensity, QString("%L1").arg(wavelength, 0, 'f', 1) );
+            } else {
+                plotObject->addPoint ( wavelength, intensity );
+            }
+            plotObject->addPoint ( wavelength, 0 );
+        }
+    }
+    m_newShift = false;
+}
+void AbstractXRaySpectra::rearrangeYList(int min, int max)
+{
+    m_yList.clear();
+    if (m_XRayType == "Transition Electric dipole") {
+        for (int i = min; i <= max; i++){
+            m_yList.append(m_edipole.at(i));
+        }
+    } else if (m_XRayType == "Electric dipole") {
+        for (int i = min; i <= max; i++){
+            m_yList.append(m_D2.at(i));
+        }
+    } else if (m_XRayType == "Magnetic dipole") {
+        for (int i = min; i <= max; i++){
+            m_yList.append(m_M2.at(i));
+        }
+    } else if (m_XRayType == "Quadrupole dipole") {
+        for (int i = min; i <= max; i++){
+            m_yList.append(m_Q2.at(i));
+        }
+    } else if (m_XRayType == "Combined") {
+        for (int i = min; i <= max; i++){
+            m_yList.append(m_combined.at(i));
+        }
+    }
+}
+
+int AbstractXRaySpectra::getXminIdx(XUnits xunit)
+{
+    int idx=m_wavelength.size()-1;
+    //    qDebug() << "m_wavelength = " << m_wavelength.at(0) << "   " << m_wavelength.at(m_wavelength.size()-1);
+    //    qDebug() << "m_energy = " << m_energy.at(0) << "   " << m_energy.at(m_energy.size()-1);
+    //    qDebug() << "m_wavenumber = " << m_wavenumber.at(0) << "   " << m_wavenumber.at(m_wavenumber.size()-1);
+
+    switch (xunit) {
+    case WAVELENGTH:
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            if ( m_wavelength.at(i) < m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case ENERGY_eV:
+        for (uint i = 0; i < m_energy.size(); i++){
+            if ( m_energy.at(i) > m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case WAVENUMBER:
+        for (uint i = 0; i < m_wavenumber.size(); i++){
+            if ( m_wavenumber.at(i) > m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    default:
+        break;
+    }
+    return idx;
+}
+int AbstractXRaySpectra::getXmaxIdx(XUnits xunit)
+{
+    int idx=m_wavelength.size()-1;
+    //    qDebug() << "m_wavelength = " << m_wavelength.at(0) << "   " << m_wavelength.at(m_wavelength.size()-1);
+    //    qDebug() << "m_energy = " << m_energy.at(0) << "   " << m_energy.at(m_energy.size()-1);
+    //    qDebug() << "m_wavenumber = " << m_wavenumber.at(0) << "   " << m_wavenumber.at(m_wavenumber.size()-1);
+
+    switch (xunit) {
+    case WAVELENGTH:
+        for (uint i= 0; i < m_wavelength.size(); i++){
+            if (m_xmax > m_wavelength.at(i)) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case ENERGY_eV:
+        for (uint i= 0; i < m_energy.size(); i++){
+            if (m_xmax < m_energy.at(i)) {
+                idx = i-1;
+                break;
+            }
+        }
+        break;
+    case WAVENUMBER:
+        for (uint i= 0; i < m_wavenumber.size(); i++){
+            if (m_xmax < m_wavenumber.at(i)) {
+                idx = i-1;
+                break;
+            }
+        }
+        break;
+    }
+    if (idx<0) idx=0;
+    return idx;
+}
+
+void  AbstractXRaySpectra::getSortIdx(std::vector<double> &sortData)
+{
+
+    int length = sortData.size();
+    m_idx.resize(length);
+    for (int i = 0; i < length; ++i) {
+        m_idx[i] =i;
+    }
+    for (int i = 0; i < length; ++i)
+    {
+        bool swapped = false;
+        for (int j = 0; j < length - (i+1); ++j)
+        {
+            if (sortData[j] < sortData[j+1])
+            {
+                swap(sortData[j], sortData[j+1]);
+                swap(m_idx[j], m_idx[j+1]);
+                swapped = true;
+            }
+        }
+
+        if (!swapped) break;
+    }
+    return;
+}
+
+}

--- a/libavogadro/src/extensions/spectra/abstract_xray.h
+++ b/libavogadro/src/extensions/spectra/abstract_xray.h
@@ -19,15 +19,15 @@
 
 //#ifdef OPENBABEL_IS_NEWER_THAN_2_2_99
 
-#ifndef SPECTRATYPE_UV_H
-#define SPECTRATYPE_UV_H
+#ifndef SPECTRATYPE_ABSTRACTXRAY_H
+#define SPECTRATYPE_ABSTRACTXRAY_H
 
 #include <QtCore/QHash>
 #include <QtCore/QVariant>
 
 #include "spectradialog.h"
 #include "spectratype.h"
-#include "ui_tab_uv.h"
+#include "ui_tab_xray.h"
 
 namespace Avogadro {
 
@@ -35,55 +35,59 @@ namespace Avogadro {
 #define cm_1_to_nm  1.e7
 #define eV_to_nm  1.e7/8065.54477
 
-  class UVSpectra : public SpectraType
+  class AbstractXRaySpectra : public SpectraType
   {
     Q_OBJECT
 
   public:
-    UVSpectra( SpectraDialog *parent = 0 );
-    ~UVSpectra();
+    AbstractXRaySpectra( SpectraDialog *parent = 0 );
 
-    void writeSettings();
-    void readSettings();
+    ~AbstractXRaySpectra(){}
 
-    bool checkForData(Molecule* mol);
-    void setupPlot(PlotWidget* plot);
+    virtual void setupPlot(PlotWidget * plot) = 0 ;
     
     void getCalculatedPlotObject(PlotObject *plotObject);
-  //  void setImportedData(const QList<double> & xList, const QList<double> & yList);
-  //  void getImportedPlotObject(PlotObject *plotObject);
-    QString getTSV();
-    QString getDataStream(PlotObject *plotObject);
-
-  private slots:
-        void changeLineShape(int);
-
-  private:
-    Ui::Tab_UV ui;
+    //  void setImportedData(const QList<double> & xList, const QList<double> & yList);
+    //  void getImportedPlotObject(PlotObject *plotObject);
 
     int getXminIdx(XUnits xunit);
     int getXmaxIdx(XUnits xunit);
     void getSortIdx(std::vector<double> &sortData);
+    void rearrangeYList(int min, int max);
+
+  protected slots:
+    void XRayTypeChanged(const QString & str);
+    void EnergyShiftSilderValueChanged(int);
+    void EnergyShiftSpinValueChanged(double);
+    void changeLineShape(int);
+
+  protected:
+    Ui::Tab_XRay ui;
+    std::vector<int> m_idx;
 
     XUnits m_XUnit;
-    YUVdata m_uvdata;
+    QString m_XRayType;
 
-    LineShape m_lineShape;          // gaussian or lorentzian peaks
+    LineShape m_lineShape;         // gaussian or lorentzian peaks
     int m_nPoints;                  // number of points of gaussian/lorentzian pulse
-
-    std::vector<int> m_idx;         // sort index for Y data
     double m_xmin, m_xmax;          // min/ max in current xunit
+    int m_XminIdx, m_XmaxIdx;       // idx of current xmin,xmax
     double m_xmin_org, m_xmax_org;  // min/max always in nm
+
+    double m_EnergyShift;           // shift in x-axis for compatibility in experiments
+    bool m_newShift;                // rescale x axis because of shift change
     bool m_resize;                  // resize x axis cause of new x unit
     bool m_newrange;                // resise x axis cause of new x range
+    std::vector<double> m_wavelength;
+    std::vector<double> m_wavenumber;
+    std::vector<double> m_energy;
 
-    std::vector<double> m_wavelength;   // wavelength in nm
-    std::vector<double> m_wavenumber;   // wavelength in cm-1
-    std::vector<double> m_energy;       // wavelength in eV
-
-        std::vector<double> m_edipole;  // transition electric dipole
-    //    std::vector<double> m_vdipole;    // transition velosity dipole
-    //    std::vector<double> m_combined;
+    std::vector<double> m_edipole;
+    std::vector<double> m_velosity;
+    std::vector<double> m_combined;
+    std::vector<double> m_D2;
+    std::vector<double> m_M2;
+    std::vector<double> m_Q2;
   };
 }
 

--- a/libavogadro/src/extensions/spectra/cd.cpp
+++ b/libavogadro/src/extensions/spectra/cd.cpp
@@ -180,6 +180,13 @@ namespace Avogadro {
     return SpectraType::getTSV("Wavelength (nm)", "Intensity (arb)");
   }
 
+
+  QString CDSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream(plotObject, "Wavelength (nm)", "Intensity (arb)");
+  }
+
+
   void CDSpectra::rotatoryTypeChanged(const QString & str) {
     if (str == "Velocity")
       m_yList = (*m_yListVelocity);

--- a/libavogadro/src/extensions/spectra/cd.cpp
+++ b/libavogadro/src/extensions/spectra/cd.cpp
@@ -47,7 +47,8 @@ namespace Avogadro {
             this, SIGNAL(plotDataChanged()));
     connect(ui.combo_rotatoryType, SIGNAL(currentIndexChanged(QString)),
             this, SLOT(rotatoryTypeChanged(QString)));
-
+    connect(ui.combo_XUnit, SIGNAL(currentIndexChanged(int)),
+            this, SIGNAL(plotDataChanged()));
     readSettings();
   }
 
@@ -60,12 +61,15 @@ namespace Avogadro {
     QSettings settings; // Already set up in avogadro/src/main.cpp
     settings.setValue("spectra/CD/gaussianWidth", ui.spin_FWHM->value());
     settings.setValue("spectra/CD/labelPeaks", ui.cb_labelPeaks->isChecked());
+    settings.setValue("spectra/CD/XUnits", ui.combo_XUnit->currentIndex());
   }
 
   void CDSpectra::readSettings() {
     QSettings settings; // Already set up in avogadro/src/main.cpp
     ui.spin_FWHM->setValue(settings.value("spectra/CD/gaussianWidth",0.0).toDouble());
     ui.cb_labelPeaks->setChecked(settings.value("spectra/CD/labelPeaks",false).toBool());
+    ui.combo_XUnit->setCurrentIndex(settings.value("spectra/UV/XUnits", WAVELENGTH).toInt());
+    m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
   }
 
   bool CDSpectra::checkForData(Molecule * mol) {
@@ -77,7 +81,14 @@ namespace Avogadro {
          etd->GetRotatoryStrengthsLength().size() == 0 ) return false;
 
     // OK, we have valid data, so store them for later
-    std::vector<double> wavelengths = etd->GetWavelengths();
+
+    m_wavelength = etd->GetWavelengths();
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i))
+                           );
+    }
+//    std::vector<double> wavelengths = etd->GetWavelengths();
     std::vector<double> rotl = etd->GetRotatoryStrengthsLength();
     std::vector<double> rotv = etd->GetRotatoryStrengthsVelocity();
 
@@ -88,8 +99,29 @@ namespace Avogadro {
     // Store in member vars
     m_xList.clear();
     m_yList.clear();
-    for (uint i = 0; i < wavelengths.size(); i++)
-      m_xList.append(wavelengths.at(i));
+
+
+    switch (m_XUnit) {
+
+    case WAVELENGTH:
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_wavelength.at(i));
+        }
+        break;
+    case ENERGY_eV:
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_energy.at(i));
+        }
+        break;
+    case WAVENUMBER:
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_wavenumber.at(i));
+        }
+        break;
+    default:
+        break; // never hit here
+    }
+
     for (uint i = 0; i < rotl.size(); i++)
       m_yListLength->append(rotl.at(i));
     for (uint i = 0; i < rotv.size(); i++)
@@ -103,7 +135,19 @@ namespace Avogadro {
 
   void CDSpectra::setupPlot(PlotWidget * plot) {
     plot->scaleLimits();
-    plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+    switch (m_XUnit) {
+    case ENERGY_eV:
+      plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Energy (eV)"));
+      break;
+    case WAVELENGTH:
+      plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+      break;
+    case WAVENUMBER:
+      plot->axis(PlotWidget::BottomAxis)->setLabel(tr("<HTML>Wavenumber (cm<sup>-1</sup>)</HTML>"));
+      break;
+    default:
+      break;
+    }
     plot->axis(PlotWidget::LeftAxis)->setLabel(tr("Intensity (arb. units)"));
   }
 
@@ -120,9 +164,32 @@ namespace Avogadro {
       ui.cb_labelPeaks->setEnabled(true);
     }
     if (!ui.cb_labelPeaks->isEnabled()) {
-      ui.cb_labelPeaks->setChecked(false);
+        ui.cb_labelPeaks->setChecked(false);
     }
 
+
+    if (m_XUnit != XUnits(ui.combo_XUnit->currentIndex())) {
+        m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+        switch (m_XUnit) {
+        case WAVELENGTH:
+            for (uint i = 0; i < m_wavelength.size(); i++){
+                m_xList.replace(i,m_wavelength.at(i));
+            }
+            break;
+        case ENERGY_eV:
+            for (uint i = 0; i < m_wavelength.size(); i++){
+                m_xList.replace(i,m_energy.at(i));
+            }
+            break;
+        case WAVENUMBER:
+            for (uint i = 0; i < m_wavelength.size(); i++){
+                m_xList.replace(i,m_wavenumber.at(i));
+            }
+            break;
+        default:
+            break; // never hit here
+        }
+    }
     if (m_xList.size() < 1 && m_yList.size() < 1) return;
 
     double wavelength, intensity;

--- a/libavogadro/src/extensions/spectra/cd.h
+++ b/libavogadro/src/extensions/spectra/cd.h
@@ -49,6 +49,7 @@ namespace Avogadro {
     //void setImportedData(const QList<double> & xList, const QList<double> & yList);
     //void getImportedPlotObject(PlotObject *plotObject);
     QString getTSV();
+    QString getDataStream(PlotObject *plotObject);
 
   private slots:
     void rotatoryTypeChanged(const QString & str);

--- a/libavogadro/src/extensions/spectra/dos.cpp
+++ b/libavogadro/src/extensions/spectra/dos.cpp
@@ -261,6 +261,11 @@ namespace Avogadro {
     return SpectraType::getTSV("Energy(eV)", "Density(e/UC)");
   }
 
+  QString DOSSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream( plotObject, "Energy(eV)", "Density(e/UC)");
+  }
+
   void DOSSpectra::toggleIntegratedDOS(bool b)
   {
     if (!b) {

--- a/libavogadro/src/extensions/spectra/dos.h
+++ b/libavogadro/src/extensions/spectra/dos.h
@@ -49,6 +49,7 @@ namespace Avogadro {
     //void setImportedData(const QList<double> & xList, const QList<double> & yList);
     void getImportedPlotObject(PlotObject *plotObject);
     QString getTSV();
+    QString getDataStream(PlotObject *plotObject);
 
     void updateDataTable() {}
 

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -171,5 +171,9 @@ namespace Avogadro {
   QString IRSpectra::getTSV() {
     return SpectraType::getTSV("Frequencies", "Intensities");
   }
-  
+
+  QString IRSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream (plotObject, "Frequencies", "Intensities");
+  }
 }

--- a/libavogadro/src/extensions/spectra/ir.cpp
+++ b/libavogadro/src/extensions/spectra/ir.cpp
@@ -51,6 +51,8 @@ namespace Avogadro {
     settings.setValue("spectra/IR/gaussianWidth", m_fwhm);
     settings.setValue("spectra/IR/labelPeaks", ui.cb_labelPeaks->isChecked());
     settings.setValue("spectra/IR/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/IR/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/IR/nPoints", ui.spin_nPoints->value());
   }
 
   void IRSpectra::readSettings() {
@@ -66,6 +68,10 @@ namespace Avogadro {
     updateYAxis(yunit);
     if (yunit == "Absorbance (%)")
       ui.combo_yaxis->setCurrentIndex(1);
+
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/IR/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.spin_nPoints->setValue(settings.value("spectra/IR/nPoints",10).toInt());
     emit plotDataChanged();
   }
 

--- a/libavogadro/src/extensions/spectra/ir.h
+++ b/libavogadro/src/extensions/spectra/ir.h
@@ -41,6 +41,7 @@ namespace Avogadro {
     void getCalculatedPlotObject(PlotObject *plotObject);
     void setImportedData(const QList<double> & xList, const QList<double> & yList);
     QString getTSV();
+    QString getDataStream(PlotObject *plotObject);
   };
 }
 

--- a/libavogadro/src/extensions/spectra/nmr.cpp
+++ b/libavogadro/src/extensions/spectra/nmr.cpp
@@ -121,7 +121,7 @@ namespace Avogadro {
     else { // Get gaussians
       // convert FWHM to sigma squared
       double FWHM = ui.spin_FWHM->value();
-      gaussianWiden(plotObject, FWHM);
+      gaussianWiden(plotObject, FWHM,10);
       /*double s2	= pow( (FWHM / (2.0 * sqrt(2.0 * log(2.0)))), 2.0);
 
       // create points

--- a/libavogadro/src/extensions/spectra/nmr.cpp
+++ b/libavogadro/src/extensions/spectra/nmr.cpp
@@ -196,6 +196,11 @@ namespace Avogadro {
     return SpectraType::getTSV("Isotropic Shift", "Intensities");
   }
 
+  QString NMRSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream ( plotObject, "Isotropic Shift", "Intensities");
+  }
+
   bool NMRSpectra::checkForData(Molecule * mol)
   {
     OpenBabel::OBMol obmol = mol->OBMol();

--- a/libavogadro/src/extensions/spectra/nmr.h
+++ b/libavogadro/src/extensions/spectra/nmr.h
@@ -46,6 +46,7 @@ namespace Avogadro {
     void setImportedData(const QList<double> & xList, const QList<double> & yList);
    // virtual void getImportedPlotObject(PlotObject *plotObject);
     virtual QString getTSV();
+    virtual QString getDataStream(PlotObject *plotObject);
 
   public slots:
     void setAtom(QString symbol);

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -61,6 +61,7 @@ namespace Avogadro {
     settings.setValue("spectra/Raman/laserWavenumber", m_W);
     settings.setValue("spectra/Raman/labelPeaks", ui.cb_labelPeaks->isChecked());
     settings.setValue("spectra/Raman/yAxisUnits", ui.combo_yaxis->currentText());
+    settings.setValue("spectra/Raman/lineShape", ui.combo_lineShape->currentIndex());
   }
 
   void RamanSpectra::readSettings() {
@@ -80,6 +81,9 @@ namespace Avogadro {
     updateYAxis(yunit);
     if (yunit == "Intensity")
       ui.combo_yaxis->setCurrentIndex(1);
+
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/Raman/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
     emit plotDataChanged();
   }
 

--- a/libavogadro/src/extensions/spectra/raman.cpp
+++ b/libavogadro/src/extensions/spectra/raman.cpp
@@ -183,7 +183,12 @@ namespace Avogadro {
   }*/
 
   QString RamanSpectra::getTSV() {
-    return SpectraType::getTSV("Frequencies", "Activities");
+      return SpectraType::getTSV("Frequencies", "Activities");
+  }
+
+  QString RamanSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream(plotObject, "Frequencies" , "Activities");
   }
 
   void RamanSpectra::updateT(double T)

--- a/libavogadro/src/extensions/spectra/raman.h
+++ b/libavogadro/src/extensions/spectra/raman.h
@@ -41,7 +41,7 @@ namespace Avogadro {
 
     void getCalculatedPlotObject(PlotObject *plotObject);
     QString getTSV();
-
+    QString getDataStream(PlotObject *plotObject);
   private slots:
     void updateT(double);
     void updateW(double);

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -26,6 +26,8 @@
 #include "uv.h"
 #include "cd.h"
 #include "raman.h"
+#include "xray_em.h"
+#include "xray_abs.h"
 
 #include <QtGui/QPen>
 #include <QtGui/QColor>
@@ -71,7 +73,8 @@ namespace Avogadro {
     m_spectra_uv = new UVSpectra(this);
     m_spectra_cd = new CDSpectra(this);
     m_spectra_raman = new RamanSpectra(this);
-
+    m_spectra_xray_abs = new XRayAbsSpectra(this);
+    m_spectra_xray_em = new XRayEmissionSpectra(this);
     // Initialize vars
     m_schemes = new QList<QHash<QString, QVariant> >;
 
@@ -158,6 +161,8 @@ namespace Avogadro {
     delete m_spectra_uv;
     delete m_spectra_cd;
     delete m_spectra_raman;
+    delete m_spectra_xray_em;
+    delete m_spectra_xray_abs;
   }
 
   void SpectraDialog::setMolecule(Molecule *molecule)
@@ -173,7 +178,8 @@ namespace Avogadro {
     m_spectra_uv->clear();
     m_spectra_cd->clear();
     m_spectra_raman->clear();
-
+    m_spectra_xray_abs->clear();
+    m_spectra_xray_em->clear();
     updatePlot();
 
     // set the filename in the image export widget
@@ -234,8 +240,20 @@ namespace Avogadro {
       ui.tab_widget->addTab(m_spectra_raman->getTabWidget(), tr("&Raman Settings"));
     }
 
+    // Check for X-Ray absorption data
+    bool hasXRay_abs = m_spectra_xray_abs->checkForData(m_molecule);
+    if (hasXRay_abs) {
+      ui.combo_spectra->addItem(tr("X-Ray Abs", "X-Ray absorption spectrum"));
+      ui.tab_widget->addTab(m_spectra_xray_abs->getTabWidget(), tr("&X-Ray Abs. Settings"));
+    }
+    // Check for X-Ray emission data
+    bool hasXRay_em = m_spectra_xray_em->checkForData(m_molecule);
+    if (hasXRay_em) {
+      ui.combo_spectra->addItem(tr("X-Ray Em", "X-Ray emission spectrum"));
+      ui.tab_widget->addTab(m_spectra_xray_em->getTabWidget(), tr("&X-Ray Em. Settings"));
+    }
     // Change this when other spectra are added!!
-    if (!hasIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman) { // Actions if there are no spectra loaded
+    if (!hasIR && !hasNMR && !hasDOS && !hasUV && !hasCD && !hasRaman && !hasXRay_abs && !hasXRay_em) { // Actions if there are no spectra loaded
       qWarning() << "SpectraDialog::setMolecule: No spectra available!";
       ui.combo_spectra->addItem(tr("No data"));
       ui.push_colorCalculated->setEnabled(false);
@@ -1057,7 +1075,7 @@ namespace Avogadro {
     QList< PlotPoint* > pointList;
     PlotObject *obj;
     PlotPoint *p;
-    double minX=0, maxX=0, minY=0, maxY=0, x=0, y=0;
+    double minX=9.9e30, maxX=0, minY=9.9e30, maxY=0, x=0, y=0;
     double x1, x2, y1, y2;
     foreach(obj, plotObjectList) {
       foreach (p, obj->points()) {
@@ -1084,8 +1102,11 @@ namespace Avogadro {
       y1 = minY-(maxY-minY)*0.1;
       y2 = maxY+(maxY-minY)*0.03;
     }
-    QRectF dataRect(x1,y1,x2,y2);
+
+    QRectF dataRect ( x1, y1, x2 - x1, y2 - y1 );
+
     QRectF fullRect(defaultRect.united(dataRect));
+
     if (defaultRect.width() < 0) {
       x1 = fullRect.left();
       x2 = fullRect.right();
@@ -1099,7 +1120,7 @@ namespace Avogadro {
       fullRect.setTop(x1);
     }
     ui.plot->setDefaultLimits(fullRect);
-    //qDebug() << fullRect.left() << fullRect.right() << fullRect.top() << fullRect.bottom();
+
     ui.plot->update();
   }
 
@@ -1123,9 +1144,14 @@ namespace Avogadro {
     else if (m_spectra == "UV")
       return m_spectra_uv;
     else if (m_spectra == "CD")
-      return m_spectra_cd;
+        return m_spectra_cd;
     else if (m_spectra == "Raman")
-      return m_spectra_raman;
+        return m_spectra_raman;
+    else if (m_spectra == "X-Ray Abs")
+        return m_spectra_xray_abs;
+    else if (m_spectra == "X-Ray Em")
+        return m_spectra_xray_em;
+
     return NULL;
   }
 

--- a/libavogadro/src/extensions/spectra/spectradialog.cpp
+++ b/libavogadro/src/extensions/spectra/spectradialog.cpp
@@ -79,6 +79,7 @@ namespace Avogadro {
     ui.tab_widget->hide();
     ui.dataTable->hide();
     ui.push_exportData->hide();
+    ui.push_exportDressedData->hide();
 
     // setting the limits for the plot
     ui.plot->setAntialiasing(true);
@@ -130,6 +131,8 @@ namespace Avogadro {
             this, SLOT(exportSpectra()));
     connect(ui.push_exportData, SIGNAL(clicked()),
             this, SLOT(exportSpectra()));
+    connect(ui.push_exportDressedData, SIGNAL(clicked()),
+            this, SLOT(exportDressedSpectra()));
     connect(ui.plot, SIGNAL(mouseOverPoint(double,double)),
             this, SLOT(showCoordinates(double,double)));
 
@@ -498,6 +501,27 @@ namespace Avogadro {
     file.close();
   }
 
+  void SpectraDialog::exportDressedSpectra()
+  {
+    // Prepare filename
+    QFileInfo defaultFile(m_molecule->fileName());
+    QString defaultPath = defaultFile.canonicalPath();
+    if (defaultPath.isEmpty()) {
+      defaultPath = QDir::homePath();
+    }
+    QString defaultFileName = defaultPath + '/' + defaultFile.baseName() + ".tsv";
+    QString filename = QFileDialog::getSaveFileName(this, tr("Export Dressed Calculated Spectrum"), defaultFileName, tr("Tab Separated Values (*.tsv)"));
+
+    // Open file
+    QFile file (filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+      qWarning() << "Cannot open file " << filename << " for writing!";
+      return;
+    }
+    QTextStream out(&file);
+    if (currentSpectra()) out << currentSpectra()->getDataStream(m_calculatedSpectra);
+    file.close();
+  }
   void SpectraDialog::importSpectra()
   {
     // Setup filename
@@ -979,32 +1003,35 @@ namespace Avogadro {
     updatePlot();
   }
 
-  void SpectraDialog::toggleAdvanced() {
-    if (ui.tab_widget->isHidden()) {
-      ui.push_advanced->setText(tr("&Advanced <<"));
-      ui.tab_widget->show();
-      ui.dataTable->show();
-      ui.push_exportData->show();
-      QSize s = size();
-      s.setWidth(s.width() + ui.dataTable->size().width());
-      s.setHeight(s.height() + ui.tab_widget->size().height());
-      QRect rect = QApplication::desktop()->screenGeometry();
-      if (s.width() > rect.width() || s.height() > rect.height())
-        s = rect.size()*0.9;
-      resize(s);
-      move(rect.width()/2 - s.width()/2, rect.height()/2 - s.height()/2);
-    }
-    else {
-      ui.push_advanced->setText(tr("&Advanced >>"));
-      QSize s = size();
-      s.setWidth(s.width() - ui.dataTable->size().width());
-      s.setHeight(s.height() - ui.tab_widget->size().height());
-      resize(s);
-      ui.tab_widget->hide();
-      ui.dataTable->hide();
-      ui.push_exportData->hide();
-      QRect rect = QApplication::desktop()->screenGeometry();
-      move(rect.width()/2 - s.width()/2, rect.height()/2 - s.height()/2);
+  void SpectraDialog::toggleAdvanced()
+  {
+      if (ui.tab_widget->isHidden()) {
+          ui.push_advanced->setText(tr("&Advanced <<"));
+          ui.tab_widget->show();
+          ui.dataTable->show();
+          ui.push_exportData->show();
+          ui.push_exportDressedData->show();
+          QSize s = size();
+          s.setWidth(s.width() + ui.dataTable->size().width());
+          s.setHeight(s.height() + ui.tab_widget->size().height());
+          QRect rect = QApplication::desktop()->screenGeometry();
+          if (s.width() > rect.width() || s.height() > rect.height())
+              s = rect.size()*0.9;
+          resize(s);
+          move(rect.width()/2 - s.width()/2, rect.height()/2 - s.height()/2);
+      }
+      else {
+        ui.push_advanced->setText(tr("&Advanced >>"));
+        QSize s = size();
+        s.setWidth(s.width() - ui.dataTable->size().width());
+        s.setHeight(s.height() - ui.tab_widget->size().height());
+        resize(s);
+        ui.tab_widget->hide();
+        ui.dataTable->hide();
+        ui.push_exportData->hide();
+        ui.push_exportDressedData->hide();
+        QRect rect = QApplication::desktop()->screenGeometry();
+        move(rect.width()/2 - s.width()/2, rect.height()/2 - s.height()/2);
     }
   }
 

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -37,6 +37,10 @@
 
 #include "ui_spectradialog.h"
 
+
+enum XUnits {WAVELENGTH, ENERGY_eV, WAVENUMBER};
+enum YUVdata {EDIPOLE, VDIPOLE, COMBINED_DIPOLE};
+
 namespace Avogadro {
 
   class SpectraType;
@@ -46,6 +50,8 @@ namespace Avogadro {
   class UVSpectra;
   class CDSpectra;
   class RamanSpectra;
+  class XRayEmissionSpectra;
+  class XRayAbsSpectra;
 
   class SpectraDialog : public QDialog
   {
@@ -102,13 +108,14 @@ namespace Avogadro {
     UVSpectra *m_spectra_uv;
     CDSpectra *m_spectra_cd;
     RamanSpectra *m_spectra_raman;
-
+    XRayEmissionSpectra *m_spectra_xray_em;
+    XRayAbsSpectra *m_spectra_xray_abs;
     Molecule *m_molecule;
     int m_scheme;
     QList<QHash<QString, QVariant> > *m_schemes;
 
     QString m_spectra;
-    SpectraType * currentSpectra();
+    SpectraType *currentSpectra();
     PlotObject *m_calculatedSpectra;
     PlotObject *m_importedSpectra;
     PlotObject *m_nullSpectra;

--- a/libavogadro/src/extensions/spectra/spectradialog.h
+++ b/libavogadro/src/extensions/spectra/spectradialog.h
@@ -86,6 +86,7 @@ namespace Avogadro {
     void removeScheme();
     void renameScheme();
     void exportSpectra();
+    void exportDressedSpectra();
     void saveImageFileDialog();
     void showCoordinates(double x,double y);
 

--- a/libavogadro/src/extensions/spectra/spectradialog.ui
+++ b/libavogadro/src/extensions/spectra/spectradialog.ui
@@ -88,7 +88,7 @@ Scroll wheel: Zoom to cursor</string>
       <bool>true</bool>
      </property>
      <attribute name="horizontalHeaderVisible">
-      <bool>true</bool>
+      <bool>false</bool>
      </attribute>
      <attribute name="horizontalHeaderCascadingSectionResizes">
       <bool>false</bool>
@@ -97,7 +97,7 @@ Scroll wheel: Zoom to cursor</string>
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderVisible">
-      <bool>true</bool>
+      <bool>false</bool>
      </attribute>
      <column>
       <property name="text">
@@ -733,7 +733,7 @@ Scroll wheel: Zoom to cursor</string>
    <item row="4" column="6">
     <widget class="QPushButton" name="push_exportDressedData">
      <property name="text">
-      <string>Export Dressed Data</string>
+      <string>Export Spectra Data</string>
      </property>
     </widget>
    </item>

--- a/libavogadro/src/extensions/spectra/spectradialog.ui
+++ b/libavogadro/src/extensions/spectra/spectradialog.ui
@@ -55,6 +55,62 @@ Scroll wheel: Zoom to cursor</string>
      </property>
     </widget>
    </item>
+   <item row="0" column="6" rowspan="3">
+    <widget class="QTableWidget" name="dataTable">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>210</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>x</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>y</string>
+      </property>
+     </column>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QComboBox" name="combo_spectra">
      <property name="sizePolicy">
@@ -104,6 +160,34 @@ Scroll wheel: Zoom to cursor</string>
      </property>
     </spacer>
    </item>
+   <item row="1" column="4">
+    <widget class="QLabel" name="currentCoordinates">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>150</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="5">
     <widget class="QPushButton" name="pushButton">
      <property name="sizePolicy">
@@ -117,7 +201,7 @@ Scroll wheel: Zoom to cursor</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" rowspan="2" colspan="6">
+   <item row="2" column="0" rowspan="3" colspan="6">
     <widget class="QTabWidget" name="tab_widget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -639,62 +723,6 @@ Scroll wheel: Zoom to cursor</string>
      </widget>
     </widget>
    </item>
-   <item row="0" column="6" rowspan="3">
-    <widget class="QTableWidget" name="dataTable">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>210</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="horizontalHeaderVisible">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="horizontalHeaderCascadingSectionResizes">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="horizontalHeaderHighlightSections">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>x</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>y</string>
-      </property>
-     </column>
-    </widget>
-   </item>
    <item row="3" column="6">
     <widget class="QPushButton" name="push_exportData">
      <property name="text">
@@ -702,31 +730,10 @@ Scroll wheel: Zoom to cursor</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
-    <widget class="QLabel" name="currentCoordinates">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>150</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
+   <item row="4" column="6">
+    <widget class="QPushButton" name="push_exportDressedData">
      <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <string>Export Dressed Data</string>
      </property>
     </widget>
    </item>

--- a/libavogadro/src/extensions/spectra/spectratype.cpp
+++ b/libavogadro/src/extensions/spectra/spectratype.cpp
@@ -85,7 +85,17 @@ namespace Avogadro {
     }
     return str;
   }
-
+  QString SpectraType::getDataStream( PlotObject *plotObject, QString xTitle, QString yTitle)
+  {
+    QString str;
+    QTextStream out (&str);
+    QString format = "%1\t%2\n";
+    out << xTitle << "\t" << yTitle << "\n";
+    for(int i = 0; i< plotObject->points().size(); i++) {
+      out << format.arg(plotObject->points().at(i)->x(), 6, 'g').arg(plotObject->points().at(i)->y(), 6, 'g');
+    }
+    return str;
+  }
   void SpectraType::updateDataTable()
   {
     if ((!m_dialog) || (m_xList.size()==0))

--- a/libavogadro/src/extensions/spectra/spectratype.cpp
+++ b/libavogadro/src/extensions/spectra/spectratype.cpp
@@ -103,11 +103,21 @@ namespace Avogadro {
     //m_dialog->getUi()->dataTable->clear();
     m_dialog->getUi()->dataTable->setRowCount(m_xList.size());
     QString format("%1");
+    int xfmtsize = 2;
+    int yfmtsize = 3;
+    if (abs(m_xList.at(0) - m_xList.at(m_xList.size()-1)) < 10) xfmtsize = 4;
+    yfmtsize = 6;
+    for (int i = 0; i < m_yList.size(); i++) {
+        if (m_yList.at(i) > 1.) {
+            yfmtsize = 3;
+            break;
+        }
+    }
     for (int i = 0; i < m_xList.size(); i++) {
-      QString xString = format.arg(m_xList.at(i), 0, 'f', 2);
+      QString xString = format.arg(m_xList.at(i), 0, 'f', xfmtsize);
       QString yString;
       if (i < m_yList.size()) {
-        yString = format.arg(m_yList.at(i), 0, 'f', 3);
+        yString = format.arg(m_yList.at(i), 0, 'f', yfmtsize);
       } else {
         yString = "-";
       }
@@ -128,23 +138,24 @@ namespace Avogadro {
   QList<double> SpectraType::getXPoints(double FWHM, uint dotsPerPeak)
   {
     QList<double> xPoints;
+
     for (int i = 0; i < m_xList.size(); i++) {
-      double x = m_xList.at(i) - (2*FWHM);
-      for (uint j = 0; j < dotsPerPeak; j++) {
-        xPoints << x;
-        x += 4*FWHM / (int(dotsPerPeak));
-      }
+        double x = m_xList.at(i) - (2*FWHM);
+        for (uint j = 0; j < dotsPerPeak; j++) {
+            xPoints << x;
+            x += 4*FWHM / (int(dotsPerPeak));
+        }
     }
     qSort(xPoints);
     return xPoints;
   }
 
-  void SpectraType::gaussianWiden(PlotObject *plotObject, const double fwhm)
+  void SpectraType::gaussianWiden(PlotObject *plotObject, const double fwhm, const int nPoints)
   {
       double s2	= pow( (fwhm / (2.0 * sqrt(2.0 * log(2.0)))), 2.0);
 
       // create points
-      QList<double> xPoints = getXPoints(fwhm, 10);
+      QList<double> xPoints = getXPoints(fwhm, nPoints);
       for (int i = 0; i < xPoints.size(); i++) {
         double x = xPoints.at(i);// already scaled!
         double y = 0;
@@ -156,7 +167,23 @@ namespace Avogadro {
         plotObject->addPoint(x,y);
       }
   }
+  void SpectraType::lorentzianWiden(PlotObject *plotObject, const double fwhm,const int nPoints)
+  {
+      double hwhm = fwhm/2.;
 
+      // create points
+      QList<double> xPoints = getXPoints(fwhm, nPoints);
+      for (int i = 0; i < xPoints.size(); i++) {
+        double x = xPoints.at(i);// already scaled!
+        double y = 0;
+        for (int j = 0; j < m_yList.size(); j++) {
+          double t = m_yList.at(j);
+          double x0 = m_xList.at(j);// already scaled!
+          y += t * hwhm /(M_PI *((x - x0)*(x - x0) + hwhm*hwhm));
+        }
+        plotObject->addPoint(x,y);
+      }
+  }
   void SpectraType::assignGaussianLabels(PlotObject *plotObject, bool findMax, double yThreshold)
   {
     for(int i = 1; i< plotObject->points().size()-1; i++) { // No border extremal points

--- a/libavogadro/src/extensions/spectra/spectratype.h
+++ b/libavogadro/src/extensions/spectra/spectratype.h
@@ -52,6 +52,7 @@ namespace Avogadro {
     virtual bool checkForData(Molecule* mol) = 0;
     virtual void setupPlot(PlotWidget * plot) = 0;
     virtual QString getTSV() = 0;
+    virtual QString getDataStream(PlotObject *plotObject) = 0;
 
     // These function have default implementations, but may be overridden    
     virtual void getCalculatedPlotObject(PlotObject *plotObject);
@@ -63,6 +64,7 @@ namespace Avogadro {
     QList<double> getXPoints(double FWHM, uint dotsPerPeak);
     QWidget * getTabWidget() {return m_tab_widget;}
     QString getTSV(QString xTitle, QString yTitle);
+    QString getDataStream(PlotObject *plotObject, QString xTitle, QString yTitle);
     void clear();
     void gaussianWiden(PlotObject *plotObject, const double fwhm);
     static void assignGaussianLabels(PlotObject *plotObject, bool findMax, double yThreshold=0);

--- a/libavogadro/src/extensions/spectra/spectratype.h
+++ b/libavogadro/src/extensions/spectra/spectratype.h
@@ -35,6 +35,8 @@
 
 namespace Avogadro {
 
+  enum LineShape { GAUSSIAN, LORENTZIAN , VOIGT};
+
   class SpectraDialog;
 
   // Abstract data type - no instance of it can be created
@@ -66,7 +68,8 @@ namespace Avogadro {
     QString getTSV(QString xTitle, QString yTitle);
     QString getDataStream(PlotObject *plotObject, QString xTitle, QString yTitle);
     void clear();
-    void gaussianWiden(PlotObject *plotObject, const double fwhm);
+    void gaussianWiden(PlotObject *plotObject, const double fwhm, const int nPoints);
+    void lorentzianWiden(PlotObject *plotObject, const double fwhm, const int nPoints);
     static void assignGaussianLabels(PlotObject *plotObject, bool findMax, double yThreshold=0);
 
   signals:
@@ -76,6 +79,9 @@ namespace Avogadro {
     SpectraDialog *m_dialog;
     QWidget *m_tab_widget;
     QList<double> m_xList, m_yList, m_xList_imp, m_yList_imp;
+    double m_yListMax;
+
+
   };
 }
 

--- a/libavogadro/src/extensions/spectra/tab_cd.ui
+++ b/libavogadro/src/extensions/spectra/tab_cd.ui
@@ -14,7 +14,7 @@
    <string>Spectra Tab</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label_9">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -30,49 +30,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="3">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="2">
-    <widget class="QCheckBox" name="cb_labelPeaks">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&amp;Label peaks</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
     <widget class="QDoubleSpinBox" name="spin_FWHM">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -91,15 +49,83 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="0" column="3">
+    <widget class="QCheckBox" name="cb_labelPeaks">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Label peaks</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>X units:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="combo_XUnit">
+     <item>
+      <property name="text">
+       <string>nm</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>eV</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>cm-1</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Rotatory Strength type:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="2" column="3">
     <widget class="QComboBox" name="combo_rotatoryType"/>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/libavogadro/src/extensions/spectra/tab_ir_raman.ui
+++ b/libavogadro/src/extensions/spectra/tab_ir_raman.ui
@@ -2,18 +2,21 @@
 <ui version="4.0">
  <class>Tab_IR_Raman</class>
  <widget class="QWidget" name="Tab_IR_Raman">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>595</width>
-    <height>271</height>
+    <width>783</width>
+    <height>288</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>tab_IR_Raman</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
@@ -33,7 +36,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="0" column="1" colspan="2">
        <widget class="QComboBox" name="combo_yaxis">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -43,7 +46,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2" colspan="2">
+      <item row="0" column="3">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -56,113 +59,7 @@
         </property>
        </spacer>
       </item>
-      <item row="6" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Scaling Type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="combo_scalingType">
-        <item>
-         <property name="text">
-          <string>Linear</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Relative</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Scale &amp;Factor:</string>
-        </property>
-        <property name="buddy">
-         <cstring>spin_scale</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QDoubleSpinBox" name="spin_scale">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="decimals">
-         <number>4</number>
-        </property>
-        <property name="minimum">
-         <double>0.000100000000000</double>
-        </property>
-        <property name="maximum">
-         <double>2.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2" colspan="2">
-       <widget class="QSlider" name="hs_scale">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>100</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimum">
-         <number>50</number>
-        </property>
-        <property name="maximum">
-         <number>150</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-        <property name="sliderPosition">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickPosition">
-         <enum>QSlider::TicksBelow</enum>
-        </property>
-        <property name="tickInterval">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
+      <item row="0" column="7">
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -175,84 +72,7 @@
         </property>
        </spacer>
       </item>
-      <item row="4" column="4">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>&amp;Gaussian Width:</string>
-        </property>
-        <property name="buddy">
-         <cstring>spin_FWHM</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QDoubleSpinBox" name="spin_FWHM">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="decimals">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <double>1000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>5.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2" colspan="2">
-       <widget class="QSlider" name="hs_FWHM">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickPosition">
-         <enum>QSlider::TicksBelow</enum>
-        </property>
-        <property name="tickInterval">
-         <number>5</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="4">
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0" colspan="4">
+      <item row="1" column="0" colspan="8">
        <widget class="QGroupBox" name="group_ramanIntensities">
         <property name="enabled">
          <bool>true</bool>
@@ -275,8 +95,8 @@
         <property name="flat">
          <bool>false</bool>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QLabel" name="label_4">
@@ -376,34 +196,54 @@
         </layout>
        </widget>
       </item>
-      <item row="7" column="0" colspan="3">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="topMargin">
-         <number>0</number>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Scaling Type:</string>
         </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QComboBox" name="combo_scalingType">
         <item>
-         <widget class="QCheckBox" name="cb_labelPeaks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+         <property name="text">
+          <string>Linear</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Relative</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="3" colspan="4">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="label_6">
           <property name="text">
-           <string>&amp;Label peaks</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
+           <string>Line Shape:</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_7">
+         <widget class="QComboBox" name="combo_lineShape">
+          <item>
+           <property name="text">
+            <string>Gaussian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Lorentzian</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -413,30 +253,269 @@
           </property>
          </spacer>
         </item>
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Threshold:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="spin_threshold">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="maximum">
-           <double>20000.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
        </layout>
+      </item>
+      <item row="2" column="7">
+       <spacer name="horizontalSpacer_9">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Scale &amp;Factor:</string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_scale</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QDoubleSpinBox" name="spin_scale">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="minimum">
+         <double>0.000100000000000</double>
+        </property>
+        <property name="maximum">
+         <double>2.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QSlider" name="hs_scale">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>100</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <number>50</number>
+        </property>
+        <property name="maximum">
+         <number>150</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="sliderPosition">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="7">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;Peak Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QDoubleSpinBox" name="spin_FWHM">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QSlider" name="hs_FWHM">
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="7">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QLabel" name="label_10">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Points per Peak:</string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QCheckBox" name="cb_labelPeaks">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;Label peaks</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="4">
+       <spacer name="horizontalSpacer_7">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Preferred</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>17</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="5" column="5">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Threshold:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="6">
+       <widget class="QDoubleSpinBox" name="spin_threshold">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maximum">
+         <double>20000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="7">
+       <spacer name="horizontalSpacer_10">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="5" column="2">
+       <widget class="QSpinBox" name="spin_nPoints">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <number>10</number>
+        </property>
+        <property name="maximum">
+         <number>25</number>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/libavogadro/src/extensions/spectra/tab_uv.ui
+++ b/libavogadro/src/extensions/spectra/tab_uv.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>260</height>
+    <width>670</width>
+    <height>189</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,46 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label_9">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>X units:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="combo_XUnit">
+     <item>
+      <property name="text">
+       <string>nm</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>eV</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>cm-1</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <spacer name="horizontalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>21</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="6">
+    <widget class="QLabel" name="label_10">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -23,40 +62,52 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&amp;Gaussian Width:</string>
+      <string>&amp;Xmin:</string>
      </property>
      <property name="buddy">
       <cstring>spin_FWHM</cstring>
      </property>
     </widget>
    </item>
-   <item row="0" column="3">
-    <spacer name="horizontalSpacer">
+   <item row="0" column="7" colspan="2">
+    <widget class="QDoubleSpinBox" name="spin_Xmin">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::NoButtons</enum>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>6</number>
+     </property>
+     <property name="maximum">
+      <double>1000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.000001000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="9">
+    <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>117</width>
        <height>20</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="2">
+   <item row="0" column="10">
     <widget class="QCheckBox" name="cb_labelPeaks">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -72,13 +123,172 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="0" column="11">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="5">
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>198</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="6">
+    <widget class="QLabel" name="label_11">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Xmax:</string>
+     </property>
+     <property name="buddy">
+      <cstring>spin_FWHM</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="7" colspan="2">
+    <widget class="QDoubleSpinBox" name="spin_Xmax">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::NoButtons</enum>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>6</number>
+     </property>
+     <property name="maximum">
+      <double>1000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.000001000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="10" rowspan="2" colspan="2">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>66</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Line Shape:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" colspan="2">
+    <widget class="QComboBox" name="combo_lineShape">
+     <item>
+      <property name="text">
+       <string>Gaussian</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Lorentzian</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <spacer name="horizontalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>1</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="5" rowspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>66</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="6" colspan="3">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>212</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_9">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;Peak Width:</string>
+     </property>
+     <property name="buddy">
+      <cstring>spin_FWHM</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2" colspan="2">
     <widget class="QDoubleSpinBox" name="spin_FWHM">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -88,6 +298,39 @@
      </property>
      <property name="singleStep">
       <double>0.500000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <spacer name="horizontalSpacer_7">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>1</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="6" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Points per Peak:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="8">
+    <widget class="QSpinBox" name="spin_nPoints">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>10</number>
+     </property>
+     <property name="maximum">
+      <number>25</number>
      </property>
     </widget>
    </item>

--- a/libavogadro/src/extensions/spectra/tab_xray.ui
+++ b/libavogadro/src/extensions/spectra/tab_xray.ui
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Tab_XRay</class>
+ <widget class="QWidget" name="Tab_XRay">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>788</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Spectra Tab</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>X-Ray Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="combo_XRayType"/>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_10">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;X min  </string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3" colspan="3">
+       <widget class="QDoubleSpinBox" name="spin_Xmin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>1000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.000001000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>17</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="7">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>36</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="8">
+       <widget class="QCheckBox" name="cb_labelPeaks">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;Label peaks</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="9">
+       <spacer name="horizontalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>36</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>X Units</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="combo_XUnit">
+        <item>
+         <property name="text">
+          <string>nm</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>eV</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>cm-1</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_11">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;X max </string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="3">
+       <widget class="QDoubleSpinBox" name="spin_Xmax">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>1000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.000001000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>17</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="8" colspan="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>152</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>98</width>
+          <height>29</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="6" rowspan="3">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>17</width>
+          <height>72</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Line Shape</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="combo_lineShape">
+        <item>
+         <property name="text">
+          <string>Gaussian</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Lorentzian</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Voigt</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="2" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Points per  Peak</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QSpinBox" name="spin_nPoints">
+        <property name="minimum">
+         <number>10</number>
+        </property>
+        <property name="maximum">
+         <number>25</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>101</width>
+          <height>24</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="1" rowspan="2">
+       <widget class="QDoubleSpinBox" name="spin_FWHM">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.250000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4" rowspan="2">
+       <widget class="QDoubleSpinBox" name="spin_FWHM_Voigt">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="maximum">
+         <double>1000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.250000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_FWHM_peak">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;Peak Width</string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2" colspan="2">
+       <widget class="QLabel" name="label_FWHM_Voigt">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;Lorentzian Width</string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_FWHM</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Energy Shift </string>
+        </property>
+        <property name="buddy">
+         <cstring>spin_EnergyShift</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QDoubleSpinBox" name="spin_EnergyShift">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-200.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>200.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2" colspan="3">
+       <widget class="QSlider" name="hs_EnergyShift">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>100</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <number>-200</number>
+        </property>
+        <property name="maximum">
+         <number>200</number>
+        </property>
+        <property name="singleStep">
+         <number>1</number>
+        </property>
+        <property name="pageStep">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="sliderPosition">
+         <number>0</number>
+        </property>
+        <property name="tracking">
+         <bool>true</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/libavogadro/src/extensions/spectra/uv.cpp
+++ b/libavogadro/src/extensions/spectra/uv.cpp
@@ -152,5 +152,9 @@ namespace Avogadro {
   QString UVSpectra::getTSV() {
     return SpectraType::getTSV("Wavelength (nm)", "Intensity (arb)");
   }
-
+  QString UVSpectra::getDataStream(PlotObject *plotObject)
+  {
+      return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity (arb)");
+//      return SpectraType::getDataStream ( *plotObject, "Frequencies" , "Activities");
+  }
 }

--- a/libavogadro/src/extensions/spectra/uv.cpp
+++ b/libavogadro/src/extensions/spectra/uv.cpp
@@ -31,9 +31,9 @@ using namespace std;
 
 namespace Avogadro {
 
-  UVSpectra::UVSpectra( SpectraDialog *parent ) :
-    SpectraType( parent )
-  {
+UVSpectra::UVSpectra( SpectraDialog *parent ) :
+    SpectraType( parent ), m_lineShape(GAUSSIAN) , m_nPoints(10)
+{
     ui.setupUi(m_tab_widget);
     // Setup signals/slots
     connect(this, SIGNAL(plotDataChanged()),
@@ -42,119 +42,441 @@ namespace Avogadro {
             this, SIGNAL(plotDataChanged()));
     connect(ui.spin_FWHM, SIGNAL(valueChanged(double)),
             this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_nPoints, SIGNAL(valueChanged(int)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_Xmin, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.spin_Xmax, SIGNAL(valueChanged(double)),
+            this, SIGNAL(plotDataChanged()));
+    connect(ui.combo_XUnit, SIGNAL(currentIndexChanged(int)),
+            this, SIGNAL(plotDataChanged()));
 
+    connect(ui.combo_lineShape, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(changeLineShape(int)));
     readSettings();
-  }
+}
 
-  UVSpectra::~UVSpectra() {
+UVSpectra::~UVSpectra() {
     // TODO: Anything to delete?
     writeSettings();
-  }
+}
 
-  void UVSpectra::writeSettings() {
+void UVSpectra::writeSettings() {
     QSettings settings; // Already set up in avogadro/src/main.cpp
     settings.setValue("spectra/UV/gaussianWidth", ui.spin_FWHM->value());
     settings.setValue("spectra/UV/labelPeaks", ui.cb_labelPeaks->isChecked());
-  }
+    settings.setValue("spectra/UV/XUnits", ui.combo_XUnit->currentIndex());
+    settings.setValue("spectra/UV/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/UV/nPoints", ui.spin_nPoints->value());
+}
 
-  void UVSpectra::readSettings() {
+void UVSpectra::readSettings() {
     QSettings settings; // Already set up in avogadro/src/main.cpp
     ui.spin_FWHM->setValue(settings.value("spectra/UV/gaussianWidth",0.0).toDouble());
     ui.cb_labelPeaks->setChecked(settings.value("spectra/UV/labelPeaks",false).toBool());
-  }
+    ui.spin_nPoints->setValue(settings.value("spectra/UV/nPoints",10).toInt());
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/UV/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.combo_XUnit->setCurrentIndex(settings.value("spectra/UV/XUnits", WAVELENGTH).toInt());
+    m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+}
 
-  bool UVSpectra::checkForData(Molecule * mol) {
+bool UVSpectra::checkForData(Molecule * mol) {
+
     OpenBabel::OBMol obmol = mol->OBMol();
     OpenBabel::OBElectronicTransitionData *etd = static_cast<OpenBabel::OBElectronicTransitionData*>(obmol.GetData("ElectronicTransitionData"));
 
     if (!etd) return false;
     if (etd->GetEDipole().size() == 0) return false;
 
+    m_wavelength.resize(0);
+    m_wavenumber.resize(0);
+    m_energy.resize(0);
+    m_edipole.resize(0);
     // OK, we have valid data, so store them for later
-    std::vector<double> wavelengths = etd->GetWavelengths();
-    std::vector<double> edipole= etd->GetEDipole();
+    m_wavelength = etd->GetWavelengths();
+    // sort for ascending wavelength
+    getSortIdx(m_wavelength);
+
+    std::vector<double> tmp_edipole = etd->GetEDipole();
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        m_edipole.push_back(tmp_edipole[m_idx[i]]);
+    }
+    // convert nm to cm-1 and eV
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i)));
+    }
 
     // Store in member vars
     m_xList.clear();
     m_yList.clear();
-    for (uint i = 0; i < wavelengths.size(); i++){
-      m_xList.append(wavelengths.at(i));
-      m_yList.append(edipole.at(i));
+
+    //    m_XUnit =  XUnits(ui.combo_XUnit->currentIndex());
+    switch (m_XUnit) {
+
+    case WAVELENGTH:
+        m_xmin = m_xmin_org = m_wavelength.at(m_wavelength.size()-1);
+        m_xmax = m_xmax_org = m_wavelength.at(0);
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_wavelength.at(i));
+            m_yList.append(m_edipole.at(i));
+        }
+        break;
+    case ENERGY_eV:
+        m_xmin = m_energy.at(0);
+        m_xmax = m_energy.at(m_wavelength.size()-1);
+        m_xmin_org = eV_to_nm / m_xmin;
+        m_xmax_org = eV_to_nm / m_xmax;
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_energy.at(i));
+            m_yList.append(m_edipole.at(i));
+        }
+        break;
+    case WAVENUMBER:
+        m_xmin = m_wavenumber.at(0);
+        m_xmax = m_wavenumber.at(m_wavelength.size()-1);
+        m_xmin_org = cm_1_to_nm/m_xmin;
+        m_xmax_org = cm_1_to_nm/m_xmax;
+
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            m_xList.append(m_wavenumber.at(i));
+            m_yList.append(m_edipole.at(i));
+        }
+        break;
+    default:
+        break; // never hit here
     }
-
+    ui.spin_Xmin->setValue(m_xmin);
+    ui.spin_Xmax->setValue(m_xmax);
     return true;
-  }
+}
 
-  void UVSpectra::setupPlot(PlotWidget * plot) {
+void UVSpectra::setupPlot(PlotWidget * plot) {
     plot->scaleLimits();
-    plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Energy (eV)"));
+        break;
+    case WAVELENGTH:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+        break;
+    case WAVENUMBER:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("<HTML>Wavenumber (cm<sup>-1</sup>)</HTML>"));
+        break;
+    default:
+        break;
+    }
+    //    plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
     plot->axis(PlotWidget::LeftAxis)->setLabel(tr("<HTML>&epsilon; (cm<sup>2</sup>/mmol)</HTML>"));
-  }
+}
 
-  void UVSpectra::getCalculatedPlotObject(PlotObject *plotObject) {
+void UVSpectra::getCalculatedPlotObject(PlotObject *plotObject){
     plotObject->clearPoints();
+    int i_xmin=0, i_xmax=0;
+    double conv_unit[3]= {1., eV_to_nm, cm_1_to_nm};
 
     if (ui.spin_FWHM->value() != 0.0 && ui.cb_labelPeaks->isEnabled()) {
-      ui.cb_labelPeaks->setEnabled(false);
-      ui.cb_labelPeaks->setChecked(false);
+        ui.cb_labelPeaks->setEnabled(false);
+        ui.cb_labelPeaks->setChecked(false);
     }
     if (ui.spin_FWHM->value() == 0.0 && !ui.cb_labelPeaks->isEnabled()) {
-      ui.cb_labelPeaks->setEnabled(true);
+        ui.cb_labelPeaks->setEnabled(true);
     }
     if (!ui.cb_labelPeaks->isEnabled()) {
-      ui.cb_labelPeaks->setChecked(false);
+        ui.cb_labelPeaks->setChecked(false);
+    }
+    // Get X units
+    m_resize = false;
+    m_newrange = false;
+    if (m_XUnit != XUnits(ui.combo_XUnit->currentIndex())) {
+        m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+        m_resize = true;
+    }
+    // Get X min
+    if (m_xmin != ui.spin_Xmin->value()) {
+        m_xmin = ui.spin_Xmin->value();
+        m_xmin_org = conv_unit[int(m_XUnit)]/m_xmin;
+        m_newrange = true;
+    }
+    // Get X max
+    if (m_xmax != ui.spin_Xmax->value()) {
+        m_xmax = ui.spin_Xmax->value();
+        m_xmax_org = conv_unit[int(m_XUnit)]/m_xmax;
+        m_newrange = true;
+    }
+
+    //    if (!m_newrange && m_resize) {
+    //        switch (m_XUnit) {
+    //        case WAVELENGTH:
+    //            for (uint i = 0; i < m_wavelength.size(); i++){
+    //                m_xList.replace(i,m_wavelength.at(i));
+    //            }
+    ////            m_xmax = getMax(WAVELENGTH);
+    ////            m_xmin = getMin(WAVELENGTH);
+    //            break;
+    //        case ENERGY_eV:
+    //            for (uint i = 0; i < m_wavelength.size(); i++){
+    //                m_xList.replace(i,m_energy.at(i));
+    //            }
+    ////            m_xmax = getMax(ENERGY_eV);
+    ////            m_xmin = getMin(ENERGY_eV);
+    //            break;
+    //        case WAVENUMBER:
+    //            for (uint i = 0; i < m_wavelength.size(); i++){
+    //                m_xList.replace(i,m_wavenumber.at(i));
+    //            }
+    //            //            m_xmax = getMax(WAVENUMBER);
+    //            //            m_xmin = getMin(WAVENUMBER);
+    //            break;
+    //        default:
+    //            break; // never hit here
+    //        }
+    //    } else
+    if (m_newrange || m_resize){
+        m_xList.clear();
+        m_yList.clear();
+        switch (m_XUnit) {
+        case WAVELENGTH:
+            i_xmax = getXmaxIdx(WAVELENGTH);
+            i_xmin = getXminIdx(WAVELENGTH);
+            if (i_xmax == i_xmin) {         // extend to all points
+                i_xmin = m_wavelength.size();
+                i_xmax = 0;
+            }
+            for (int i = i_xmax; i < i_xmin; i++){
+                m_xList.append(m_wavelength.at(i));
+                m_yList.append(m_edipole.at(i));
+            }
+            break;
+        case ENERGY_eV:
+            i_xmax = getXmaxIdx(ENERGY_eV);
+            i_xmin = getXminIdx(ENERGY_eV);
+            if (i_xmax == i_xmin) {         // extend to all points
+                i_xmin = 0;
+                i_xmax = m_energy.size();
+            }
+            for (int i = i_xmin; i < i_xmax; i++){
+                m_xList.append(m_energy.at(i));
+                m_yList.append(m_edipole.at(i));
+            }
+            break;
+        case WAVENUMBER:
+            i_xmax = getXmaxIdx(WAVENUMBER);
+            i_xmin = getXminIdx(WAVENUMBER);
+            if (i_xmax == i_xmin) {         // extend to all points
+                i_xmin = 0;
+                i_xmax = m_wavenumber.size();
+            }
+            for (int i = i_xmin; i < i_xmax; i++){
+                m_xList.append(m_wavenumber.at(i));
+                m_yList.append(m_edipole.at(i));
+            }
+            break;
+        default:
+            break; // never hit here
+        }
     }
 
     if (m_xList.size() < 1 && m_yList.size() < 1) return;
 
     double wavelength, intensity;
     double FWHM = ui.spin_FWHM->value();
+    m_nPoints = ui.spin_nPoints->value();
+
     bool use_widening = (FWHM == 0) ? false : true;
 
     if (use_widening) {
-      // convert FWHM to sigma squared
-      double sigma = FWHM / (2.0 * sqrt(2.0 * log(2.0)));
-      double s2	= pow( sigma, 2.0 );
+        if (m_lineShape == GAUSSIAN) {  // gaussian shape
 
-      // create points
-      QList<double> xPoints = getXPoints(FWHM, 25);
-      for (int i = 0; i < xPoints.size(); i++) {
-        double x = xPoints.at(i);
-        double y = 0.0;
-        for (int j = 0; j < m_yList.size(); j++) {
-          double t = m_yList.at(j);
-          double w = m_xList.at(j);
-          y += t * exp( - ( pow( (x - w), 2 ) ) / (2 * s2) ) *
-            // Normalization factor: (CP, 224 (1997) 143-155)
-            2.87e4 / sqrt(2 * M_PI * s2);
-        }
-        plotObject->addPoint(x,y);
-      }
-    }
-    else {
-      for (int i = 0; i < m_yList.size(); i++) {
-        wavelength = m_xList.at(i);
-        intensity = m_yList.at(i) *
-          // Normalization factor:
-          2.87e4;
-        plotObject->addPoint ( wavelength, 0 );
-        if (ui.cb_labelPeaks->isChecked()) {
-          // %L1 uses localized number format (e.g., 1.023,4 in Europe)
-          plotObject->addPoint( wavelength, intensity, QString("%L1").arg(wavelength, 0, 'f', 1) );
-        } else {
-        plotObject->addPoint ( wavelength, intensity );
-        }
-        plotObject->addPoint ( wavelength, 0 );
-      }
-    }
-  }
+            // convert FWHM to sigma squared
 
-  QString UVSpectra::getTSV() {
+            double sigma = FWHM / (2.0 * sqrt(2.0 * log(2.0)));
+            double s2	= sigma*sigma;
+
+            // create points
+
+            QList<double> xPoints = getXPoints(FWHM, m_nPoints);
+
+            for (int i = 0; i < xPoints.size(); i++) {
+                double x = xPoints.at(i);
+                double y = 0.0;
+
+                for (int j = 0; j < m_yList.size(); j++) {
+                    double t = m_yList.at(j);
+                    double w = m_xList.at(j);
+
+                    y += t * exp( - ( pow( (x - w), 2 ) ) / (2 * s2) ) *
+                            // Normalization factor: (CP, 224 (1997) 143-155)
+                            2.87e4 / sqrt(2 * M_PI * s2);
+                }
+
+                plotObject->addPoint(x,y);
+            }
+        } else {     // lorentzian shape
+            double hwhm= FWHM /2.0;
+
+            // create points
+
+            QList<double> xPoints = getXPoints(FWHM, m_nPoints);
+
+            for (int i = 0; i < xPoints.size(); i++) {
+                double x = xPoints.at(i);
+                double y = 0.0;
+
+                for (int j = 0; j < m_yList.size(); j++) {
+                    double t = m_yList.at(j);
+                    double x0 = m_xList.at(j);
+
+                    y += 2.87e4 * t * hwhm / (M_PI * ((x-x0)*(x-x0) + hwhm*hwhm));  // Normalization factor: (CP, 224 (1997) 143-155)
+                }
+                plotObject->addPoint(x,y);
+            }
+        }
+    }
+    else {  // only points
+        for (int i = 0; i < m_yList.size(); i++) {
+
+            wavelength = m_xList.at(i);
+            intensity = m_yList.at(i) * 2.87e4; // Normalization factor:
+
+            plotObject->addPoint ( wavelength, 0 );
+            if (ui.cb_labelPeaks->isChecked()) {
+                // %L1 uses localized number format (e.g., 1.023,4 in Europe)
+                plotObject->addPoint( wavelength, intensity, QString("%L1").arg(wavelength, 0, 'f', 1) );
+            } else {
+                plotObject->addPoint ( wavelength, intensity );
+            }
+            plotObject->addPoint ( wavelength, 0 );
+        }
+    }
+}
+int UVSpectra::getXminIdx(XUnits xunit)
+{
+    int idx=m_wavelength.size();
+    switch (xunit) {
+    case WAVELENGTH:
+        for (uint i = 0; i < m_wavelength.size(); i++){
+            if ( m_wavelength.at(i) < m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case ENERGY_eV:
+        for (uint i = 0; i < m_energy.size(); i++){
+            if ( m_energy.at(i) > m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case WAVENUMBER:
+        for (uint i = 0; i < m_wavenumber.size(); i++){
+            if ( m_wavenumber.at(i) > m_xmin) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    default:
+        break;
+    }
+    return idx;
+}
+int UVSpectra::getXmaxIdx(XUnits xunit)
+{
+    int idx=m_wavelength.size();
+
+    switch (xunit) {
+    case WAVELENGTH:
+        for (uint i= 0; i < m_wavelength.size(); i++){
+            if (m_xmax > m_wavelength.at(i)) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case ENERGY_eV:
+        for (uint i= 0; i < m_energy.size(); i++){
+            if (m_xmax < m_energy.at(i)) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    case WAVENUMBER:
+        for (uint i= 0; i < m_wavenumber.size(); i++){
+            if (m_xmax < m_wavenumber.at(i)) {
+                idx = i;
+                break;
+            }
+        }
+        break;
+    }
+    return idx;
+}
+//
+// choose line shape - gaussian or lorentzian
+//
+void UVSpectra::changeLineShape(int type)
+{
+    m_lineShape = static_cast<LineShape>(type);
+//    if (m_lineShape == GAUSSIAN || m_lineShape == LORENTZIAN) {
+//        ui.label_FWHM_Voigt->hide();
+//        ui.spin_FWHM_Voigt->hide();
+//        ui.label_FWHM_peak->setText("Peak Width");
+//    } else if (m_lineShape == VOIGT) {
+//        ui.label_FWHM_Voigt->show();
+//        ui.spin_FWHM_Voigt->show();
+//        ui.label_FWHM_peak->setText("Gaussian Width");
+//    }
+    emit plotDataChanged();
+}
+
+QString UVSpectra::getTSV() {
     return SpectraType::getTSV("Wavelength (nm)", "Intensity (arb)");
-  }
-  QString UVSpectra::getDataStream(PlotObject *plotObject)
-  {
-      return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity (arb)");
-//      return SpectraType::getDataStream ( *plotObject, "Frequencies" , "Activities");
-  }
+}
+QString UVSpectra::getDataStream(PlotObject *plotObject)
+{
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        return SpectraType::getDataStream ( plotObject, "Energy (eV)" ,"Intensity (arb)");
+        break;
+    case WAVELENGTH:
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity (arb)");
+        break;
+    case WAVENUMBER:
+        return SpectraType::getDataStream ( plotObject, "Wavenumber cm-1" ,"Intensity (arb)");
+        break;
+    default:    // never hit here
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity (arb)");
+        break;
+    }
+}
+
+void  UVSpectra::getSortIdx(std::vector<double> &sortData)
+{
+
+        int length = sortData.size();
+        m_idx.resize(length);
+        for (int i = 0; i < length; ++i) m_idx[i] =i;
+        for (int i = 0; i < length; ++i)
+        {
+            bool swapped = false;
+            for (int j = 0; j < length - (i+1); ++j)
+            {
+                if (sortData[j] < sortData[j+1])
+                {
+                    swap(sortData[j], sortData[j+1]);
+                    swap(m_idx[j], m_idx[j+1]);
+                    swapped = true;
+                }
+            }
+
+            if (!swapped) break;
+        }
+        return;
+}
+
 }

--- a/libavogadro/src/extensions/spectra/uv.h
+++ b/libavogadro/src/extensions/spectra/uv.h
@@ -49,7 +49,7 @@ namespace Avogadro {
   //  void setImportedData(const QList<double> & xList, const QList<double> & yList);
   //  void getImportedPlotObject(PlotObject *plotObject);
     QString getTSV();
-
+    QString getDataStream(PlotObject *plotObject);
   private:
     Ui::Tab_UV ui;
     double m_fermi;

--- a/libavogadro/src/extensions/spectra/xray_abs.cpp
+++ b/libavogadro/src/extensions/spectra/xray_abs.cpp
@@ -1,0 +1,236 @@
+/**********************************************************************
+  SpectraDialog - Visualize spectral data from QM calculations
+
+  Copyright (C) 2009 by David Lonie
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Library General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ ***********************************************************************/
+
+#include <openbabel/generic.h>
+
+#include "xray_abs.h"
+#include "spectradialog.h"
+
+#include <QtGui/QMessageBox>
+#include <QtCore/QDebug>
+
+#include <openbabel/mol.h>
+
+using namespace std;
+
+namespace Avogadro {
+
+XRayAbsSpectra::XRayAbsSpectra( SpectraDialog *parent ) :
+    AbstractXRaySpectra( parent )
+{
+    readSettings();
+    if (m_lineShape == GAUSSIAN || m_lineShape == LORENTZIAN) {
+        ui.label_FWHM_Voigt->hide();
+        ui.spin_FWHM_Voigt->hide();
+        ui.label_FWHM_peak->setText("Peak Width");
+    } else if (m_lineShape == VOIGT) {
+        ui.label_FWHM_Voigt->show();
+        ui.spin_FWHM_Voigt->show();
+        ui.label_FWHM_peak->setText("Gaussian Width");
+    }
+}
+
+XRayAbsSpectra::~XRayAbsSpectra() {
+    // TODO: Anything to delete?
+    writeSettings();
+}
+
+void XRayAbsSpectra::writeSettings() {
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+    settings.setValue("spectra/XRay/Absoprtion/gaussianWidth", ui.spin_FWHM->value());
+    settings.setValue("spectra/XRay/Absoprtion/labelPeaks", ui.cb_labelPeaks->isChecked());
+    settings.setValue("spectra/XRay/Absoprtion/XUnits", ui.combo_XUnit->currentIndex());
+    settings.setValue("spectra/XRay/Absoprtion/lineShape", ui.combo_lineShape->currentIndex());
+    settings.setValue("spectra/XRay/Absorption/nPoints", ui.spin_nPoints->value());
+}
+
+void XRayAbsSpectra::readSettings() {
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+    ui.spin_FWHM->setValue(settings.value("spectra/XRay/Absoprtion/gaussianWidth",0.0).toDouble());
+    ui.cb_labelPeaks->setChecked(settings.value("spectra/XRay/Absoprtion/labelPeaks",false).toBool());
+    ui.spin_nPoints->setValue(settings.value("spectra/XRay/Absoprtion/nPoints",10).toInt());
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/XRay/Absoprtion/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+    ui.combo_XUnit->setCurrentIndex(settings.value("spectra/XRay/Absoprtion/XUnits", WAVELENGTH).toInt());
+    m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+//    m_EnergyShift = ui.spin_EnergyShift;
+}
+
+bool XRayAbsSpectra::checkForData(Molecule * mol) {
+
+    OpenBabel::OBMol obmol = mol->OBMol();
+    OpenBabel::OBXrayORCAData *osd = static_cast<OpenBabel::OBXrayORCAData*>(obmol.GetData("ORCASpectraData"));
+
+    if (!osd) return false;
+    if (!osd->GetXRayData()) return false;
+    if (osd->GetAbsEDipole().size() == 0) return false;
+
+    m_wavelength.resize(0);
+    m_wavenumber.resize(0);
+    m_energy.resize(0);
+    m_edipole.resize(0);
+
+    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined, tmp_D2, tmp_M2, tmp_Q2;
+
+    // OK, we have valid data, so store them for later
+    m_wavelength = osd->GetAbsWavelengths();
+    // sort for ascending wavelength
+    getSortIdx(m_wavelength);
+
+    tmp_edipole = osd->GetAbsEDipole();
+    if (osd->GetAbsVelocity().size() != 0)  tmp_velosity = osd->GetAbsVelocity();
+    if (osd->GetAbsCombined().size() != 0) {
+        tmp_combined = osd->GetAbsCombined();
+        tmp_D2 = osd->GetAbsD2();
+        tmp_M2 = osd->GetAbsM2();
+        tmp_Q2 = osd->GetAbsQ2();
+    }
+
+    // resort data
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        m_edipole.push_back(tmp_edipole[m_idx[i]]);
+    }
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        if (osd->GetAbsCombined().size() != 0) {
+            m_combined.push_back(tmp_combined[m_idx[i]]);
+            m_D2.push_back(tmp_D2[m_idx[i]]*tmp_combined[m_idx[i]]);
+            m_M2.push_back(tmp_M2[m_idx[i]]*tmp_combined[m_idx[i]]);
+            m_Q2.push_back(tmp_Q2[m_idx[i]]*tmp_combined[m_idx[i]]);
+        }
+    }
+
+    // convert nm to cm-1 and eV
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i)));
+    }
+
+    // Store in member vars
+    m_xList.clear();
+    m_yList.clear();
+    switch (m_XUnit) {
+
+    case WAVELENGTH:
+        m_XminIdx = m_wavelength.size()-1;
+        m_xmin = m_xmin_org = m_wavelength.at(m_XminIdx);
+        m_XmaxIdx = 0;
+        m_xmax = m_xmax_org = m_wavelength.at(m_XmaxIdx);
+        for (int i = m_XmaxIdx; i <= m_XminIdx; i++){
+            m_xList.append(m_wavelength.at(i));
+        }
+        break;
+    case ENERGY_eV:
+        m_XminIdx = 0;
+        m_xmin = m_energy.at(m_XminIdx);
+        m_XmaxIdx = m_energy.size()-1;
+        m_xmax = m_energy.at(m_XmaxIdx);
+        m_xmin_org = eV_to_nm / m_xmin;
+        m_xmax_org = eV_to_nm / m_xmax;
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_energy.at(i));
+        }
+        break;
+    case WAVENUMBER:
+        m_XminIdx = 0;
+        m_xmin = m_wavenumber.at(m_XminIdx);
+        m_XmaxIdx = m_wavenumber.size()-1;
+        m_xmax = m_wavenumber.at(m_XmaxIdx);
+        m_xmin_org = cm_1_to_nm/m_xmin;
+        m_xmax_org = cm_1_to_nm/m_xmax;
+
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_wavenumber.at(i));
+        }
+        break;
+    default:
+        break; // never hit here
+    }
+    ui.spin_Xmin->setValue(m_xmin);
+    ui.spin_Xmax->setValue(m_xmax);
+
+    ui.combo_XRayType->clear();
+    if (m_edipole.size() != 0) ui.combo_XRayType->addItem("Transition Electric dipole");
+    if (m_velosity.size() != 0) ui.combo_XRayType->addItem("Electric velosity");
+    if (m_D2.size() != 0) ui.combo_XRayType->addItem("Electric dipole");
+    if (m_M2.size() != 0) ui.combo_XRayType->addItem("Magnetic dipole");
+    if (m_Q2.size() != 0) ui.combo_XRayType->addItem("Quadrupole dipole");
+    if (m_combined.size() != 0) ui.combo_XRayType->addItem("Combined");
+    XRayTypeChanged(ui.combo_XRayType->currentText());
+    return true;
+}
+
+void XRayAbsSpectra::setupPlot(PlotWidget * plot) {
+    plot->scaleLimits();
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Energy (eV)"));
+        break;
+    case WAVELENGTH:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+        break;
+    case WAVENUMBER:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("<HTML>Wavenumber (cm<sup>-1</sup>)</HTML>"));
+        break;
+    default:
+        break;
+    }
+    plot->axis(PlotWidget::LeftAxis)->setLabel(tr("Intensity"));
+}
+
+void XRayAbsSpectra::getCalculatedPlotObject(PlotObject *plotObject){
+    AbstractXRaySpectra::getCalculatedPlotObject(plotObject);
+}
+
+QString XRayAbsSpectra::getTSV() {
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        return SpectraType::getTSV ( "Energy (eV)" ,"Intensity");
+        break;
+    case WAVELENGTH:
+        return SpectraType::getTSV ( "Wavelength (nm)" ,"Intensity");
+        break;
+    case WAVENUMBER:
+        return SpectraType::getTSV ( "Wavenumber (cm-1)" ,"Intensity");
+        break;
+    default:
+        return SpectraType::getTSV ( "Wavelength (nm)" ,"Intensity");
+        break;
+    }
+}
+QString XRayAbsSpectra::getDataStream(PlotObject *plotObject)
+{
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        return SpectraType::getDataStream ( plotObject, "Energy (eV)" ,"Intensity");
+        break;
+    case WAVELENGTH:
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity");
+        break;
+    case WAVENUMBER:
+        return SpectraType::getDataStream ( plotObject, "Wavenumber (cm-1)" ,"Intensity");
+        break;
+    default:
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity");
+        break;
+    }
+}
+
+
+
+}

--- a/libavogadro/src/extensions/spectra/xray_abs.h
+++ b/libavogadro/src/extensions/spectra/xray_abs.h
@@ -19,50 +19,44 @@
 
 //#ifdef OPENBABEL_IS_NEWER_THAN_2_2_99
 
-#ifndef SPECTRATYPE_CD_H
-#define SPECTRATYPE_CD_H
+#ifndef SPECTRATYPE_XRAY_ABS_H
+#define SPECTRATYPE_XRAY_ABS_H
 
-#include <QHash>
-#include <QVariant>
+#include <QtCore/QHash>
+#include <QtCore/QVariant>
 
 #include "spectradialog.h"
-#include "spectratype.h"
-#include "ui_tab_cd.h"
+#include "abstract_xray.h"
+//#include "spectratype.h"
+#include "ui_tab_xray.h"
 
 namespace Avogadro {
 
-  class CDSpectra : public SpectraType
+
+#define cm_1_to_nm  1.e7
+#define eV_to_nm  1.e7/8065.54477
+
+  class XRayAbsSpectra : public AbstractXRaySpectra
   {
     Q_OBJECT
 
   public:
-    CDSpectra( SpectraDialog *parent = 0 );
-    ~CDSpectra();
+    XRayAbsSpectra( SpectraDialog *parent = 0 );
+    ~XRayAbsSpectra();
 
     void writeSettings();
     void readSettings();
 
     bool checkForData(Molecule* mol);
     void setupPlot(PlotWidget * plot);
-
+    
     void getCalculatedPlotObject(PlotObject *plotObject);
-    //void setImportedData(const QList<double> & xList, const QList<double> & yList);
-    //void getImportedPlotObject(PlotObject *plotObject);
+  //  void setImportedData(const QList<double> & xList, const QList<double> & yList);
+  //  void getImportedPlotObject(PlotObject *plotObject);
     QString getTSV();
     QString getDataStream(PlotObject *plotObject);
-
-  private slots:
-    void rotatoryTypeChanged(const QString & str);
-
   private:
-    Ui::Tab_CD ui;
-    QList<double> *m_yListVelocity, *m_yListLength;
-    double m_fermi;
 
-    XUnits m_XUnit;
-    std::vector<double> m_wavelength;
-    std::vector<double> m_wavenumber;
-    std::vector<double> m_energy;
   };
 }
 

--- a/libavogadro/src/extensions/spectra/xray_em.cpp
+++ b/libavogadro/src/extensions/spectra/xray_em.cpp
@@ -1,0 +1,240 @@
+/**********************************************************************
+  SpectraDialog - Visualize spectral data from QM calculations
+
+  Copyright (C) 2009 by David Lonie
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.cc/>
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Library General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ ***********************************************************************/
+
+#include <openbabel/generic.h>
+
+#include "xray_em.h"
+#include "spectradialog.h"
+
+#include <QtGui/QMessageBox>
+#include <QtCore/QDebug>
+
+#include <openbabel/mol.h>
+
+using namespace std;
+
+namespace Avogadro {
+
+XRayEmissionSpectra::XRayEmissionSpectra( SpectraDialog *parent ) :
+    AbstractXRaySpectra( parent )
+{
+    readSettings();
+    if (m_lineShape == GAUSSIAN || m_lineShape == LORENTZIAN) {
+        ui.label_FWHM_Voigt->hide();
+        ui.spin_FWHM_Voigt->hide();
+        ui.label_FWHM_peak->setText("Peak Width");
+    } else if (m_lineShape == VOIGT) {
+        ui.label_FWHM_Voigt->show();
+        ui.spin_FWHM_Voigt->show();
+        ui.label_FWHM_peak->setText("Gaussian Width");
+    }
+}
+
+XRayEmissionSpectra::~XRayEmissionSpectra() {
+    // TODO: Anything to delete?
+    writeSettings();
+}
+
+void XRayEmissionSpectra::writeSettings() {
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+    settings.setValue("spectra/XRay/Emission/gaussianWidth", ui.spin_FWHM->value());
+    settings.setValue("spectra/XRay/Emission/labelPeaks", ui.cb_labelPeaks->isChecked());
+    settings.setValue("spectra/XRay/Emission/XUnits", ui.combo_XUnit->currentIndex());
+    settings.setValue("spectra/XRay/Emission/nPoints", ui.spin_nPoints->value());
+    settings.setValue("spectra/XRay/Emission/lineShape", ui.combo_lineShape->currentIndex());
+}
+
+void XRayEmissionSpectra::readSettings() {
+    QSettings settings; // Already set up in avogadro/src/main.cpp
+    ui.spin_FWHM->setValue(settings.value("spectra/XRay/Emission/gaussianWidth",0.0).toDouble());
+    ui.cb_labelPeaks->setChecked(settings.value("spectra/XRay/Emission/labelPeaks",false).toBool());
+    ui.spin_nPoints->setValue(settings.value("spectra/XRay/Emission/nPoints",10).toInt());
+    ui.combo_lineShape->setCurrentIndex(settings.value("spectra/XRay/Emission/lineShape", GAUSSIAN).toInt());
+    m_lineShape = LineShape(ui.combo_lineShape->currentIndex());
+
+    ui.combo_XUnit->setCurrentIndex(settings.value("spectra/XRay/Emission/XUnits", WAVELENGTH).toInt());
+    m_XUnit = XUnits(ui.combo_XUnit->currentIndex());
+//    m_EnergyShift = ui.spin_EnergyShift;
+}
+
+bool XRayEmissionSpectra::checkForData(Molecule * mol) {
+
+    OpenBabel::OBMol obmol = mol->OBMol();
+    OpenBabel::OBXrayORCAData *osd = static_cast<OpenBabel::OBXrayORCAData*>(obmol.GetData("ORCASpectraData"));
+
+    if (!osd) return false;
+    if (!osd->GetXRayData()) return false;
+    if (osd->GetEmEDipole().size() == 0) return false;
+
+    m_wavelength.resize(0);
+    m_wavenumber.resize(0);
+    m_energy.resize(0);
+    m_edipole.resize(0);
+
+    std::vector<double> tmp_edipole, tmp_velosity, tmp_combined, tmp_D2, tmp_M2, tmp_Q2;
+
+    // OK, we have valid data, so store them for later
+    m_wavelength = osd->GetEmWavelengths();
+    // sort for ascending wavelength
+    getSortIdx(m_wavelength);
+
+    tmp_edipole = osd->GetEmEDipole();
+    if (osd->GetEmVelosity().size() != 0)  tmp_velosity = osd->GetEmVelosity();
+    if (osd->GetEmCombined().size() != 0) {
+        tmp_combined = osd->GetEmCombined();
+        tmp_D2 = osd->GetEmD2();
+        tmp_M2 = osd->GetEmM2();
+        tmp_Q2 = osd->GetEmQ2();
+    }
+
+    // resort data
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        m_edipole.push_back(tmp_edipole[m_idx[i]]);
+    }
+    for (uint i = 0; i < tmp_edipole.size(); i++){
+        if (osd->GetEmCombined().size() != 0) {
+            m_combined.push_back(tmp_combined[m_idx[i]]);
+            m_D2.push_back(tmp_D2[m_idx[i]]);
+            m_M2.push_back(tmp_M2[m_idx[i]]);
+            m_Q2.push_back(tmp_Q2[m_idx[i]]);
+        }
+    }
+
+    // convert nm to cm-1 and eV
+    for (uint i = 0; i < m_wavelength.size(); i++){
+        m_wavenumber.push_back(1.e7/m_wavelength.at(i));
+        m_energy.push_back(1.e7/(8065.54477*m_wavelength.at(i)));
+    }
+
+    // Store in member vars
+    m_xList.clear();
+    m_yList.clear();
+
+    //    m_XUnit =  XUnits(ui.combo_XUnit->currentIndex());
+    switch (m_XUnit) {
+
+    case WAVELENGTH:
+        m_XminIdx = m_wavelength.size()-1;
+        m_xmin = m_xmin_org = m_wavelength.at(m_XminIdx);
+        m_XmaxIdx = 0;
+        m_xmax = m_xmax_org = m_wavelength.at(m_XmaxIdx);
+        for (int i = m_XmaxIdx; i <= m_XminIdx; i++){
+            m_xList.append(m_wavelength.at(i));
+        }
+        break;
+    case ENERGY_eV:
+        m_XminIdx = 0;
+        m_xmin = m_energy.at(m_XminIdx);
+        m_XmaxIdx = m_energy.size()-1;
+        m_xmax = m_energy.at(m_XmaxIdx);
+        m_xmin_org = eV_to_nm / m_xmin;
+        m_xmax_org = eV_to_nm / m_xmax;
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_energy.at(i));
+        }
+        break;
+    case WAVENUMBER:
+        m_XminIdx = 0;
+        m_xmin = m_wavenumber.at(m_XminIdx);
+        m_XmaxIdx = m_wavenumber.size()-1;
+        m_xmax = m_wavenumber.at(m_XmaxIdx);
+        m_xmin_org = cm_1_to_nm/m_xmin;
+        m_xmax_org = cm_1_to_nm/m_xmax;
+
+        for (int i = m_XminIdx; i <= m_XmaxIdx; i++){
+            m_xList.append(m_wavenumber.at(i));
+        }
+        break;
+    default:
+        break; // never hit here
+    }
+    ui.spin_Xmin->setValue(m_xmin);
+    ui.spin_Xmax->setValue(m_xmax);
+
+    ui.combo_XRayType->clear();
+    if (m_edipole.size() != 0) ui.combo_XRayType->addItem("Electric dipole");
+    if (m_velosity.size() != 0) ui.combo_XRayType->addItem("Electric velosity");
+    if (m_D2.size() != 0) ui.combo_XRayType->addItem("Electric dipole/total");
+    if (m_M2.size() != 0) ui.combo_XRayType->addItem("Magnetic dipole/total");
+    if (m_Q2.size() != 0) ui.combo_XRayType->addItem("Quadrupole dipole/total");
+    if (m_combined.size() != 0) ui.combo_XRayType->addItem("Combined");
+    XRayTypeChanged(ui.combo_XRayType->currentText());
+    return true;
+}
+
+void XRayEmissionSpectra::setupPlot(PlotWidget * plot) {
+    plot->scaleLimits();
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Energy (eV)"));
+        break;
+    case WAVELENGTH:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("Wavelength (nm)"));
+        break;
+    case WAVENUMBER:
+        plot->axis(PlotWidget::BottomAxis)->setLabel(tr("<HTML>Wavenumber (cm<sup>-1</sup>)</HTML>"));
+        break;
+    default:
+        break;
+    }
+    plot->axis(PlotWidget::LeftAxis)->setLabel(tr("Intensity"));
+}
+
+void XRayEmissionSpectra::getCalculatedPlotObject(PlotObject *plotObject){
+    AbstractXRaySpectra::getCalculatedPlotObject(plotObject);
+}
+
+QString XRayEmissionSpectra::getTSV()
+{
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        return SpectraType::getTSV ( "Energy (eV)" ,"Intensity");
+        break;
+    case WAVELENGTH:
+        return SpectraType::getTSV ( "Wavelength (nm)" ,"Intensity");
+        break;
+    case WAVENUMBER:
+        return SpectraType::getTSV ( "Wavenumber (cm-1)" ,"Intensity");
+        break;
+    default:
+        return SpectraType::getTSV ( "Wavelength (nm)" ,"Intensity");
+        break;
+    }
+}
+QString XRayEmissionSpectra::getDataStream(PlotObject *plotObject)
+{
+    switch (m_XUnit) {
+    case ENERGY_eV:
+        return SpectraType::getDataStream ( plotObject, "Energy (eV)" ,"Intensity");
+        break;
+    case WAVELENGTH:
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity");
+        break;
+    case WAVENUMBER:
+        return SpectraType::getDataStream ( plotObject, "Wavenumber cm-1" ,"Intensity");
+        break;
+    default:
+        return SpectraType::getDataStream ( plotObject, "Wavelength (nm)" ,"Intensity");
+        break;
+    }
+}
+
+
+
+}

--- a/libavogadro/src/extensions/spectra/xray_em.h
+++ b/libavogadro/src/extensions/spectra/xray_em.h
@@ -19,50 +19,44 @@
 
 //#ifdef OPENBABEL_IS_NEWER_THAN_2_2_99
 
-#ifndef SPECTRATYPE_CD_H
-#define SPECTRATYPE_CD_H
+#ifndef SPECTRATYPE_XRAY_EM_H
+#define SPECTRATYPE_XRAY_EM_H
 
-#include <QHash>
-#include <QVariant>
+#include <QtCore/QHash>
+#include <QtCore/QVariant>
 
 #include "spectradialog.h"
-#include "spectratype.h"
-#include "ui_tab_cd.h"
+#include "abstract_xray.h"
+//#include "spectratype.h"
+#include "ui_tab_xray.h"
 
 namespace Avogadro {
 
-  class CDSpectra : public SpectraType
+
+#define cm_1_to_nm  1.e7
+#define eV_to_nm  1.e7/8065.54477
+
+  class XRayEmissionSpectra : public AbstractXRaySpectra
   {
     Q_OBJECT
 
   public:
-    CDSpectra( SpectraDialog *parent = 0 );
-    ~CDSpectra();
+    XRayEmissionSpectra( SpectraDialog *parent = 0 );
+    ~XRayEmissionSpectra();
 
     void writeSettings();
     void readSettings();
 
     bool checkForData(Molecule* mol);
     void setupPlot(PlotWidget * plot);
-
+    
     void getCalculatedPlotObject(PlotObject *plotObject);
-    //void setImportedData(const QList<double> & xList, const QList<double> & yList);
-    //void getImportedPlotObject(PlotObject *plotObject);
+  //  void setImportedData(const QList<double> & xList, const QList<double> & yList);
+  //  void getImportedPlotObject(PlotObject *plotObject);
     QString getTSV();
     QString getDataStream(PlotObject *plotObject);
-
-  private slots:
-    void rotatoryTypeChanged(const QString & str);
-
   private:
-    Ui::Tab_CD ui;
-    QList<double> *m_yListVelocity, *m_yListLength;
-    double m_fermi;
 
-    XUnits m_XUnit;
-    std::vector<double> m_wavelength;
-    std::vector<double> m_wavenumber;
-    std::vector<double> m_energy;
   };
 }
 

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -66,7 +66,8 @@ namespace Avogadro{
                           invalidRings(true), invalidGroupIndices(true),
                           obmol(0), obunitcell(0),
                           obvibdata(0), obdosdata(0),
-                          obelectronictransitiondata(0)
+                          obelectronictransitiondata(0),
+                          obxrayorcadata(0)
     {}
     // These are logically cached variables and thus are marked as mutable.
     // Const objects should be logically constant (and not mutable)
@@ -105,6 +106,7 @@ namespace Avogadro{
       OpenBabel::OBDOSData *        obdosdata;
       OpenBabel::OBElectronicTransitionData *
                                     obelectronictransitiondata;
+      OpenBabel::OBXrayORCAData * obxrayorcadata;
   };
 
   Molecule::Molecule(QObject *parent) : Primitive(MoleculeType, parent),
@@ -1289,6 +1291,11 @@ namespace Avogadro{
       obmol.SetData(d->obelectronictransitiondata->Clone(&obmol));
     }
 
+
+    // Copy xray spectra data, if needed
+    if (d->obxrayorcadata != NULL) {
+      obmol.SetData(d->obxrayorcadata->Clone(&obmol));
+    }
     return obmol;
   }
 
@@ -1463,7 +1470,16 @@ namespace Avogadro{
       d->obelectronictransitiondata = etd;
     }
 
+    // Copy Xray spectra data
+    if (obmol->HasData(OpenBabel::OBGenericDataType::CustomData0)) {
+      OpenBabel::OBXrayORCAData *xrayorca =
+        static_cast<OpenBabel::OBXrayORCAData*>
+        (obmol->GetData(OpenBabel::OBGenericDataType::CustomData0));
+      d->obxrayorcadata = xrayorca;
+    }
+
     // Copy orbital energies, symbols, and occupations to dynamic properties (as QList<>)
+    qDebug() << "has data  = " << obmol->HasData(OpenBabel::OBGenericDataType::ElectronicData) << endl;
     if (obmol->HasData(OpenBabel::OBGenericDataType::ElectronicData)) {
       OpenBabel::OBOrbitalData *od =
         static_cast<OpenBabel::OBOrbitalData*>(obmol->GetData(OpenBabel::OBGenericDataType::ElectronicData));

--- a/libavogadro/src/plotwidget.cpp
+++ b/libavogadro/src/plotwidget.cpp
@@ -210,12 +210,19 @@ namespace Avogadro {
         }
       }
     }
+
+//    qDebug() << "xmin = " << xmin;
+//    qDebug() << "xmax = " << xmax;
+//    qDebug() << "ymin = " << ymin;
+//    qDebug() << "ymax = " << ymax;
+
     double xspread = xmax - xmin;
     double yspread = ymax - ymin;
     xmin -= xspread * 0.05;
     xmax += xspread * 0.05;
     ymin -= yspread * 0.05;
     ymax += yspread * 0.05;
+
     setDefaultLimits( xmin, xmax, ymin, ymax );
   }
 
@@ -232,6 +239,7 @@ namespace Avogadro {
       y1 -= 0.5;
     }
     d->defaultDataRect = QRectF( x1, y1, x2 - x1, y2 - y1 );
+//    qDebug() << "( x1, y1, x2 - x1, y2 - y1 )  " <<  x1 << " " << y1 << " " <<  x2 - x1 << " " << y2 - y1  << endl;
     setLimits( x1, x2, y1, y2 );
   }
 
@@ -266,8 +274,17 @@ namespace Avogadro {
       YA2 = YA1 + 0.5;
       YA1 -= 0.5;
     }
-
+//    qDebug() << "xmin = " << XA1;
+//    qDebug() << "xmax = " << XA2;
+//    qDebug() << "xwidth = " << XA2 - XA1;
+//    qDebug() << "ymin = " << YA1;
+//    qDebug() << "yheight = " << YA2 - YA1;
     dataRect = QRectF( XA1, YA1, XA2 - XA1, YA2 - YA1 );
+
+//    qDebug() << "dataRect.x = " << dataRect.x();
+//    qDebug() << "dataRect.width= " << dataRect.width();
+//    qDebug() << "dataRect.y = " << dataRect.y();
+//    qDebug() << "dataRect.height = " << dataRect.height();
 
     q->axis( LeftAxis )->setTickMarks( dataRect.y(), dataRect.height() );
     q->axis( BottomAxis )->setTickMarks( dataRect.x(), dataRect.width() );


### PR DESCRIPTION
supports displaying X-Ray spectra but therefore devOpenbabelwithORCA4.0 is needed! 
supports new basisset syntax - ORCA 4.0 uses - in the ORCA extension plugin